### PR TITLE
security: warn against ever adding a PR trigger to the self-hosted runner job

### DIFF
--- a/.github/workflows/publish-edge.yml
+++ b/.github/workflows/publish-edge.yml
@@ -203,6 +203,13 @@ jobs:
   # Runs on a self-hosted runner inside the intranet so it has direct
   # network access to the demo's Watchtower instance. The token is a
   # bearer auth secret stored in the repo settings.
+  #
+  # ⚠️ SECURITY: this repo is public and this job runs on a self-hosted
+  # runner. The whole workflow only triggers on `push: branches: [main]`
+  # (direct push only — merges are now gated by branch protection). NEVER
+  # add a `pull_request` or `pull_request_target` trigger to this workflow,
+  # or to any job that runs on `self-hosted` — that turns any fork PR into
+  # arbitrary code execution on the intranet runner.
   deploy-demo:
     needs: merge
     runs-on: [self-hosted, intranet]


### PR DESCRIPTION
## Summary
- Add explicit warning comment above the `deploy-demo` self-hosted-runner job: never add a `pull_request`/`pull_request_target` trigger, since this repo is public and that would turn a fork PR into code execution on the intranet runner.
- Companion to branch protection now enabled on `main` (requires PRs to merge).

Found during a wdk-ansible infrastructure security assessment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)