### PR TITLE
fix(release): stop a mirror registry from failing the whole release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,4 +71,10 @@ jobs:
           # Quay image names can pull their namespace from a single secret
           # rather than being hardcoded.
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          # Empty when Quay is not configured, which disables that push in
+          # .goreleaser.yaml rather than failing the release at the last step.
           QUAY_NAMESPACE: ${{ secrets.QUAY_NAMESPACE }}
+          # Set the repository variable QUAY_SKIP to "1" to publish without Quay —
+          # the escape hatch for a rejected or expired robot token, so a mirror
+          # cannot hold up a release.
+          QUAY_SKIP: ${{ vars.QUAY_SKIP }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -68,13 +68,48 @@ changelog:
       order: 999
 
 dockers_v2:
-  - dockerfile: Dockerfile
-    # Docker Hub and Quay namespaces come from env vars set by release.yml
-    # (DOCKERHUB_USERNAME, QUAY_NAMESPACE) so they can be changed without
-    # touching this file. GHCR namespace is the GitHub org name and stable.
+  # GHCR and Docker Hub. release.yml already treats every registry but GHCR as
+  # optional — it skips the login when the token is absent — but this file used to
+  # push to all three unconditionally, so one registry refusing a token failed the
+  # whole release *after* the other two had been written. v2.4.0 hit exactly that:
+  # the images reached GHCR and Docker Hub, Quay answered 401, and GoReleaser
+  # aborted before creating the GitHub release, leaving no binaries and no notes.
+  #
+  # Quay is now its own entry so it can be skipped without taking the release with
+  # it. The mirrors are a convenience; the release is not.
+  - id: primary
+    dockerfile: Dockerfile
+    # Docker Hub namespace comes from an env var set by release.yml
+    # (DOCKERHUB_USERNAME) so it can be changed without touching this file.
+    # The GHCR namespace is the GitHub org name and is stable.
     images:
       - "ghcr.io/jp1337/easywall"
       - "docker.io/{{ .Env.DOCKERHUB_USERNAME }}/easywall"
+    tags:
+      - "{{ .Tag }}"
+      - "latest"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    build_args:
+      VERSION: "{{ .Version }}"
+    extra_files:
+      - go.mod
+      - go.sum
+      - cmd/
+      - internal/
+      - web/
+      - locales/
+      - config/
+      - docker/
+
+  # Skipped when QUAY_NAMESPACE is unset, or when QUAY_SKIP is set to "1" — which
+  # is how a rejected or expired robot token gets worked around without editing
+  # this file or holding up a release.
+  - id: quay
+    disable: '{{ or (eq .Env.QUAY_NAMESPACE "") (eq .Env.QUAY_SKIP "1") }}'
+    dockerfile: Dockerfile
+    images:
       - "quay.io/{{ .Env.QUAY_NAMESPACE }}/easywall"
     tags:
       - "{{ .Tag }}"


### PR DESCRIPTION
The v2.4.0 release failed. It pushed to GHCR and Docker Hub, then Quay answered
`401 UNAUTHORIZED` on a blob HEAD and GoReleaser aborted — before creating the
GitHub release. The result: two registries carrying `v2.4.0`, no release notes, no
binaries, no checksums, and a tag that looks published but is not.

## The disagreement

`release.yml` already treats every registry but GHCR as optional — it skips the
login step when the token is absent:

```yaml
- name: Log in to Quay.io
  if: env.QUAY_TOKEN != ''
```

`.goreleaser.yaml` did not honour that and pushed to all three unconditionally. So
the two files disagreed about whether a mirror was required, and the way you find
out is a half-published release.

## The change

Quay becomes its own `dockers_v2` entry, disabled when `QUAY_NAMESPACE` is empty
or the `QUAY_SKIP` repository variable is `"1"`. The mirrors are a convenience;
the release is not, and a rejected robot token should not be able to hold one up.

`QUAY_SKIP` is set to `1` right now. The `QUAY_TOKEN` secret exists — it was
created 2026-05-03 — but the registry rejects it, so it needs a new token on the
Quay side. Clearing the variable re-enables the push with no code change.

## After merging

The `v2.4.0` tag has to be recreated: a tag-triggered run reads both the workflow
and the GoReleaser config from the tagged commit, so re-running the existing tag
would fail the same way. Nothing has consumed v2.4.0 yet — there is no GitHub
release to invalidate — and the images will be rebuilt from the tag that ends up
published, so tag and image content match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)