### PR TITLE
docs: SEO groundwork for the published site (sitemap, robots, og:image, Ko-fi)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,6 +56,7 @@ jobs:
           pages=$(find _site -name '*.html' | wc -l)
           echo "$pages HTML pages built"
           test -f _site/index.html || { echo "::error::no landing page was built"; exit 1; }
+          test -f _site/sitemap.xml || { echo "::error::no sitemap.xml was built; the sitemap plugin is broken"; exit 1; }
           [ "$pages" -ge 15 ] || {
             echo "::error::only $pages pages built; the site has more than that, so something was dropped"
             exit 1
@@ -104,6 +105,7 @@ jobs:
           pages=$(find _site -name '*.html' | wc -l)
           echo "$pages HTML pages built"
           test -f _site/index.html || { echo "::error::no landing page was built"; exit 1; }
+          test -f _site/sitemap.xml || { echo "::error::no sitemap.xml was built; the sitemap plugin is broken"; exit 1; }
           [ "$pages" -ge 15 ] || {
             echo "::error::only $pages pages built; the site has more than that, so something was dropped"
             exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ backup/*
 .DS_Store
 .vscode/
 .idea/
+.worktrees/
 *.swp
 *.swo
 *~

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
   <a href="https://go.dev"><img src="https://img.shields.io/github/go-mod/go-version/jp1337/easywall?logo=go&logoColor=white&label=go" alt="Go version"></a>
   <a href="https://www.gnu.org/licenses/gpl-3.0"><img src="https://img.shields.io/github/license/jp1337/easywall?logo=opensourceinitiative&logoColor=white&label=license&color=blue" alt="GPL-3.0"></a>
   <a href="https://discord.gg/3zJMvChvUA"><img src="https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://ko-fi.com/jp1337"><img src="https://img.shields.io/badge/ko--fi-support-13C3FF?logo=kofi&logoColor=white" alt="Support on Ko-fi"></a>
 </p>
 
 <p align="center">

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3"
 gem "jekyll-seo-tag", "~> 2.8"
+gem "jekyll-sitemap", "~> 1.4"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -21,6 +21,16 @@ version: "2.6.0"
 tagline: "Your firewall. Your rules. No surprises."
 logo: /assets/img/icon.svg
 
+# jekyll-seo-tag reads og:image / twitter:image only from page.image (front
+# matter), never from site.logo. A defaults block sets it once for every page,
+# so each share link carries the real 1200x630 image instead of no image at a
+# all. A page can still override it by declaring its own `image:`.
+defaults:
+  - scope:
+      path: ""
+    values:
+      image: /assets/img/og-image.png
+
 # The support server. A permanent invite — checked against Discord's own invite
 # API, which reports no expiry — so it can be printed in a README that outlives
 # any one release. Set here once; the footer and the pages read it from the site
@@ -47,6 +57,7 @@ kramdown:
 
 plugins:
   - jekyll-seo-tag
+  - jekyll-sitemap
 
 exclude:
   - Gemfile

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://easywall-project.org/sitemap.xml


### PR DESCRIPTION
Based on a quick SEO pass for the freshly-moved domain.

**Published site (easywall-project.org)**
- add `jekyll-sitemap` (Gemfile + _config.yml) so Google/Bing can discover every page via a sitemap
- front-matter default sets the real 1200x630 `og:image` on all pages (jekyll-seo-tag reads page.image, not site.logo)
- `docs/robots.txt`: allow crawling + point at the sitemap
- `docs.yml` now asserts `_site/sitemap.xml` exists in both the PR and deploy build

**Repo discoverability**
- README: a Ko-fi support badge, matching the existing shields.io row (ko-fi.com/jp1337, the handle the funding guard test allows)

Verified locally by building the Jekyll site in a container: sitemap.xml (23 URLs), robots.txt and og:image all present; payment-link guard tests green.