### PR TITLE
docs: SoftwareApplication schema, keyword-first home title, one title tag

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -18,13 +18,40 @@
   </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% if page.title %}{{ page.title }} — {% endif %}easywall docs</title>
   <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
   <link rel="preload" href="{{ '/assets/fonts/inter-var.woff2' | relative_url }}" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="{{ '/assets/fonts/jetbrains-mono-var.woff2' | relative_url }}" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}?v=3">
   <link rel="icon" type="image/svg+xml" href="{{ '/assets/img/icon.svg' | relative_url }}">
   {% seo %}
+
+  {%- if page.seo == "software" -%}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "{{ site.title }}",
+    "url": "{{ site.url }}/",
+    "description": "{{ site.description }}",
+    "applicationCategory": "SecurityApplication",
+    "operatingSystem": "Linux",
+    "softwareVersion": "{{ site.version }}",
+    "license": "https://www.gnu.org/licenses/gpl-3.0",
+    "image": "{{ '/assets/img/og-image.png' | absolute_url }}",
+    "author": {
+      "@type": "Person",
+      "name": "{{ site.author.name }}",
+      "url": "{{ site.author.url }}"
+    },
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "EUR"
+    },
+    "releaseNotes": "https://github.com/jp1337/easywall/releases/latest"
+  }
+  </script>
+  {%- endif -%}
 </head>
 <body>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,8 @@
 ---
 layout: default
-title: Home
+title: easywall — nftables firewall with a web interface
 description: Linux firewall management with a web interface. Go, nftables via netlink, two-process privilege isolation, and an apply that undoes itself if you get it wrong.
+seo: software
 ---
 
 <div class="docs-hero">


### PR DESCRIPTION
Three SEO fixes on the published site (easywall-project.org).

- **SoftwareApplication JSON-LD** on the homepage only (front-matter flag), for rich results: SecurityApplication, Linux, version from the site config, GPL-3.0, free offer.
- **Homepage title** now leads with the keyword: `easywall — nftables firewall with a web interface` instead of `Home`.
- **Removed the duplicate <title>**: the layout emitted a manual title while jekyll-seo-tag emitted a second conflicting one, on every page, shipped that way on the live site. seo-tag is now the single source; verified exactly one title across all 23 pages.

Performance checked, no urgent action (lean fonts/CSS, per-theme screenshots).