### PR TITLE
fix(ci): install the .deb in a container, not on the runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,9 +126,43 @@ jobs:
   # No GOARCH anywhere: debian/control says `Architecture: any` and debian/rules
   # calls a plain `go build`, so the runner decides what comes out. That is also
   # what makes the file name right — dpkg names it from DEB_HOST_ARCH.
+  #
+  # This package is a firewall, and since 2.7 (the boot-restore release)
+  # easywall-core programs nftables into the kernel the instant it starts —
+  # "default drop until confirmed" begins at process start, not at the first
+  # apply. This job used to install the .deb straight onto the runner that is
+  # executing it, via `sudo apt-get install -y ./dist/*.deb`, and postinst
+  # starts easywall-core.service unconditionally. That handed the runner its
+  # own `input policy drop`. The job did not crash — it lost its route back to
+  # the Actions service, so it froze at whatever step happened to be running
+  # when the rule landed: install, a purely local check, the artifact upload —
+  # a different step each run, because it depends on exactly when the runner's
+  # own connection got cut, not on anything the job itself does wrong. With no
+  # timeout on the job it then sat for roughly 47 minutes before the platform
+  # gave up, against ~2 minutes for a green run.
+  #
+  # release.yml builds this exact same package and has never shown any of
+  # this, for one reason: it only builds. It never installs what it builds, so
+  # postinst never runs anywhere near the machine executing the job.
+  #
+  # The fix is not to install less — the coverage that matters is that the
+  # package actually starts, because a previous release shipped one that
+  # didn't and nothing here caught it. The fix is to give the install
+  # somewhere to point nftables that isn't the runner's own network
+  # namespace: a privileged container gets its own netns, so the rules land
+  # there and the runner keeps its network throughout. The checks need
+  # systemd for real, so ubuntu:24.04 (which ships none) installs systemd and
+  # execs it as PID 1 before the package goes anywhere near apt. That last
+  # part matters on its own: debian/postinst only starts the services
+  # `if [ -d /run/systemd/system ]`, and that directory only exists once
+  # systemd is actually running — so a container where systemd never came up
+  # would "install" the package, start nothing, and every check below would
+  # report nothing running and call it a pass. Systemd's readiness is
+  # therefore asserted before the install, not inferred from it.
   build-deb:
     name: Debian Package (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -166,7 +200,9 @@ jobs:
         run: mkdir -p dist && mv ../*.deb dist/
 
       # The one mistake a file name cannot show: a package that says arm64 and
-      # carries amd64 binaries. Ask the artefact for both.
+      # carries amd64 binaries. Ask the artefact for both. Pure inspection —
+      # dpkg-deb and tar, nothing is installed — so this still runs on the
+      # runner itself.
       - name: It is a package for this architecture
         run: |
           set -euo pipefail
@@ -187,24 +223,79 @@ jobs:
           }
           echo "ok  $deb is $got and carries a $got binary"
 
+      # Uploaded here, before anything installs the package — not last, where
+      # it used to be. A hang during install used to cost the artifact too: a
+      # step with nothing to do with building lost the thing that was already
+      # built and already proven to be the right architecture.
+      - name: Upload .deb artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: debian-package-${{ matrix.arch }}
+          path: dist/*.deb
+          retention-days: 7
+
+      # ── Everything from here on installs the package. That happens inside a
+      # privileged container with its own network namespace, never on the
+      # runner — see the job-level comment for why. Docker is preinstalled on
+      # both runner flavours and ubuntu:24.04 is multi-arch, so the same
+      # recipe works unmodified on ubuntu-24.04-arm.
+      - name: Start a systemd container
+        run: |
+          docker run -d --name easywall-test \
+            --privileged --cgroupns=host \
+            -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+            -v "${{ github.workspace }}/dist:/dist:ro" \
+            ubuntu:24.04 \
+            bash -c "apt-get update -qq && apt-get install -y systemd systemd-sysv curl python3 && exec /sbin/init"
+
+      # See the job-level comment: postinst only starts the services once
+      # /run/systemd/system exists, which only happens once systemd is truly
+      # PID 1 and running — not once the container is merely "up". Installing
+      # the package before this is confirmed would silently skip the coverage
+      # this job exists for.
+      - name: Assert systemd is actually running before installing anything
+        run: |
+          set -euo pipefail
+          state=""
+          for i in $(seq 1 60); do
+            state=$(docker exec easywall-test systemctl is-system-running 2>/dev/null || true)
+            echo "systemd state: ${state:-<not answering yet>}"
+            case "$state" in
+              running|degraded) break ;;
+            esac
+            sleep 1
+          done
+          case "$state" in
+            running|degraded) echo "ok  systemd is $state inside the container" ;;
+            *)
+              echo "::error::systemd never came up in the container (last state: '${state:-none}') — installing the package now would prove nothing"
+              docker logs easywall-test --tail 100 || true
+              exit 1
+              ;;
+          esac
+
       # Building the package proved it compiles. It never proved it installs —
       # and it did not: postinst left /etc/easywall unreadable by the user the
       # web service runs as, so a freshly installed package had no web
-      # interface at all. That shipped because nothing here went past the build.
+      # interface at all. That shipped because nothing here went past the
+      # build. apt-get, not dpkg -i, so the runtime dependencies in
+      # debian/control get pulled in inside the container, same as a real user
+      # installing the package would.
       - name: Install the package
-        run: sudo apt-get install -y ./dist/*.deb
+        run: docker exec easywall-test bash -c "apt-get update -qq && apt-get install -y /dist/*.deb"
 
       - name: Check the installed layout
         run: |
+          docker exec -i easywall-test bash -s <<'EOF'
           set -euo pipefail
           fail=0
-          # Through sudo, because the layout being checked is the reason a plain
-          # stat cannot do it: /etc/easywall is 0750 root:easywall and the runner
-          # user is in neither. The check that reads the permissions has to be
-          # allowed past them, or it reports "Permission denied" for the
-          # arrangement working exactly as intended.
+          # Plain stat, no sudo: docker exec is root by default inside the
+          # container, which is exactly the access the runner-side version of
+          # this check needed sudo for. /etc/easywall is still 0750
+          # root:easywall — that arrangement is what is under test, not worked
+          # around.
           check() { # path expected_owner expected_mode
-            actual=$(sudo stat -c '%U:%G %a' "$1")
+            actual=$(stat -c '%U:%G %a' "$1")
             if [ "$actual" != "$2 $3" ]; then
               echo "::error::$1 is '$actual', expected '$2 $3'"
               fail=1
@@ -228,6 +319,7 @@ jobs:
           # the core does not need CAP_DAC_OVERRIDE to reach it.
           check /var/lib/easywall        root:easywall     770
           exit $fail
+          EOF
 
       # The package starts both services itself. Everything below asks the
       # installed system what it is doing rather than starting a second copy by
@@ -235,6 +327,7 @@ jobs:
       # daemon that never came up would not have been noticed.
       - name: Check both services are running
         run: |
+          docker exec -i easywall-test bash -s <<'EOF'
           set -euo pipefail
           for unit in easywall-core easywall-web; do
             for i in $(seq 1 20); do
@@ -249,6 +342,7 @@ jobs:
             }
             echo "ok  $unit is active"
           done
+          EOF
 
       # The regression that made a fresh install useless: the unit reduces the
       # daemon's capabilities to CAP_NET_ADMIN, which also removes CAP_CHOWN, so
@@ -257,17 +351,17 @@ jobs:
       - name: Check the web user can reach the core
         run: |
           set -euo pipefail
-          # sudo for the same reason as the layout check: /run/easywall is 0750
-          # root:easywall and the runner is in neither, which is the arrangement
-          # being verified. Only the reading is privileged — the connection below
-          # is made as the easywall user, which is the thing under test.
-          sudo ls -l /run/easywall/core.sock
-          owner=$(sudo stat -c '%U:%G' /run/easywall/core.sock)
+          docker exec easywall-test ls -l /run/easywall/core.sock
+          owner=$(docker exec easywall-test stat -c '%U:%G' /run/easywall/core.sock)
           [ "$owner" = "root:easywall" ] || {
             echo "::error::the control socket is $owner, not root:easywall — easywall-web cannot connect"
             exit 1
           }
-          sudo -u easywall python3 - <<'PY'
+          # --user drops to the easywall user for the connection itself, the
+          # same drop `sudo -u easywall` made when this ran directly on the
+          # runner — the design says that user, not root, is what may reach
+          # the socket, so that is who has to be the one asking.
+          docker exec -i --user easywall easywall-test python3 - <<'PY'
           import json, socket, sys
           s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
           s.settimeout(5)
@@ -284,7 +378,7 @@ jobs:
               sys.exit(1)
           print("the core answered the web user:", str(reply)[:80])
           PY
-          sudo test -s /var/lib/easywall/rules.json || {
+          docker exec easywall-test test -s /var/lib/easywall/rules.json || {
             echo "::error::the core never wrote its rule store — it cannot reach /var/lib/easywall"
             exit 1
           }
@@ -293,16 +387,16 @@ jobs:
         run: |
           set -euo pipefail
           for i in $(seq 1 20); do
-            curl -sk -o /dev/null https://127.0.0.1:12227/firstrun && break
+            docker exec easywall-test curl -sk -o /dev/null https://127.0.0.1:12227/firstrun && break
             sleep 0.5
           done
-          code=$(curl -sk -o /dev/null -w '%{http_code}' https://127.0.0.1:12227/firstrun)
+          code=$(docker exec easywall-test curl -sk -o /dev/null -w '%{http_code}' https://127.0.0.1:12227/firstrun)
           echo "GET /firstrun -> $code"
           [ "$code" = "200" ] || { echo "::error::the web interface did not come up"; exit 1; }
-          # sudo again: ssl/ is 0750 easywall:easywall, so only the web user and
-          # root can see the certificate it generates — which is the point of it.
-          sudo test -s /etc/easywall/ssl/cert.pem || { echo "::error::no certificate was generated"; exit 1; }
-          if sudo -u easywall sh -c 'echo x >> /etc/easywall/easywall.toml' 2>/dev/null; then
+          # ssl/ is 0750 easywall:easywall, so only the web user and root can
+          # see the certificate it generates — which is the point of it.
+          docker exec easywall-test test -s /etc/easywall/ssl/cert.pem || { echo "::error::no certificate was generated"; exit 1; }
+          if docker exec --user easywall easywall-test sh -c 'echo x >> /etc/easywall/easywall.toml' 2>/dev/null; then
             echo "::error::the web user can write the core's configuration"
             exit 1
           fi
@@ -311,12 +405,15 @@ jobs:
       # The version reaches the binary. It is written in with -ldflags -X, which
       # does nothing at all when the target is a constant — as it was, so every
       # released binary reported the literal in the source instead of its tag.
+      # dpkg-parsechangelog reads debian/changelog from the checkout, so that
+      # half stays on the runner; only the installed binary is asked inside the
+      # container.
       - name: Check the version was compiled in
         run: |
           set -euo pipefail
           want=$(dpkg-parsechangelog --show-field Version)
           for bin in easywall-core easywall-web; do
-            got=$(/usr/sbin/$bin --version | awk '{print $2}')
+            got=$(docker exec easywall-test /usr/sbin/$bin --version | awk '{print $2}')
             echo "$bin --version -> $got (package $want)"
             [ "$got" = "$want" ] || {
               echo "::error::$bin reports $got but the package is $want — the -ldflags version injection is not landing"
@@ -324,9 +421,6 @@ jobs:
             }
           done
 
-      - name: Upload .deb artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: debian-package-${{ matrix.arch }}
-          path: dist/*.deb
-          retention-days: 7
+      - name: Stop the container
+        if: always()
+        run: docker rm -f easywall-test || true

--- a/internal/shared/workflow_order_test.go
+++ b/internal/shared/workflow_order_test.go
@@ -186,9 +186,32 @@ func TestEveryImageArchitectureAlsoGetsAPackage(t *testing.T) {
 }
 
 // The package job has to install what it builds, on the architecture it built
-// it for. A cross-built package that nothing installs is how this repository
-// shipped a .deb with no binaries in it for its whole existence.
-func TestBothPackageArchitecturesAreInstalledNatively(t *testing.T) {
+// it for, and it has to do that installation inside a container rather than
+// on the runner itself.
+//
+// The first half is old: a cross-built package that nothing installs is how
+// this repository shipped a .deb with no binaries in it for its whole
+// existence.
+//
+// The second half is the more expensive lesson. build-deb was green through
+// 2026-08-17 and red on every branch from 2026-08-18: the 2.7 boot-restore
+// change made easywall-core program nftables into the kernel the moment it
+// starts, and debian/postinst starts that service unconditionally. Installing
+// the .deb straight onto the runner — which is what this job did until then,
+// via a plain `apt-get install -y ./dist/*.deb` — handed the runner its own
+// `input policy drop`. The runner does not crash; it loses its own route back
+// to the Actions service, so the job hangs at whatever step happened to be
+// running when the rule landed, until the platform times it out around the
+// 47-minute mark. release.yml builds the identical package and was never
+// touched by any of this, for one reason: it only ever builds. It never
+// installs what it builds, so postinst never runs anywhere near the machine
+// executing that job.
+//
+// So this test checks two things that both have to hold, and neither implies
+// the other: the job installs the package it built (not just compiles it),
+// and it does that installation somewhere other than the runner's own network
+// namespace.
+func TestPackageInstallsNativelyInsideAContainer(t *testing.T) {
 	block := jobBlock(t, repoFile(t, ".github", "workflows", "build.yml"), "build-deb")
 
 	for _, want := range []string{"ubuntu-24.04\n", "ubuntu-24.04-arm"} {
@@ -197,7 +220,25 @@ func TestBothPackageArchitecturesAreInstalledNatively(t *testing.T) {
 				"cross-built or not built at all", strings.TrimSpace(want))
 		}
 	}
-	if !strings.Contains(block, "apt-get install -y ./dist/*.deb") {
-		t.Error("the package job no longer installs the package it builds")
+
+	// The exact path (`./dist/*.deb`) is not the point — a bind mount, a `docker
+	// cp`, or a renamed directory can all change it without changing the thing
+	// under test. What has to hold is that some line actually runs `apt-get
+	// install` against a .deb, wherever it lives.
+	installLine := regexp.MustCompile(`(?m)^.*apt-get install[^\n]*\.deb.*$`).FindString(block)
+	if installLine == "" {
+		t.Fatal("the package job no longer installs the package it builds")
+	}
+
+	// The incident above, made permanent: that install line must run inside a
+	// container, never directly against the runner.
+	if !strings.Contains(installLine, "docker exec") {
+		t.Errorf("the package is installed by a command that does not run through "+
+			"`docker exec`:\n  %s\n"+
+			"installing this package puts a firewall with input policy drop on "+
+			"whatever machine runs that command — on the runner itself, that is the "+
+			"runner executing the job. It loses its own route back to the Actions "+
+			"service and the job hangs until the platform gives up on it.",
+			strings.TrimSpace(installLine))
 	}
 }


### PR DESCRIPTION
## Diagnosis

`build-deb` installed the built `.deb` straight onto the GitHub-hosted runner executing the job (`sudo apt-get install -y ./dist/*.deb`). `debian/postinst` starts `easywall-core.service` unconditionally, and since release 2.7 (the boot-restore work) the core programs nftables into the kernel the instant it starts — "default drop until confirmed" begins at process start, not at the first apply. So the job installed a firewall onto the machine running the job.

The job didn't crash. It lost its own route back to the Actions service, so it froze at whatever step happened to be executing when the rule landed — install, a purely local check, the artifact upload — a different step each run, because it depends on exactly when the runner's own connection got cut. With no `timeout-minutes` on the job, it then sat for roughly 47 minutes before the platform gave up, against ~2 minutes for a green run.

Evidence:
- Last green `build.yml` run 2026-08-17 19:42; first red 2026-08-18 18:28 on the 2.7 branch; `main` red immediately after merge. The boot-restore change landed 2026-08-18.
- `release.yml` builds the exact same package and has always been green, because it only builds — it never installs what it builds, so postinst never runs anywhere near the machine executing that job.

## Fix

Give the install somewhere to point nftables that isn't the runner's own network namespace:

1. **`timeout-minutes: 15`** on `build-deb`, so a hang can never again cost 47 minutes.
2. **`Upload .deb artifact` moved before any installation.** It used to be last, so a hang during install cost the artifact too, even though upload has nothing to do with building.
3. **Install and every check now run inside a privileged container** (`docker run --privileged --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw ubuntu:24.04 ...`) with its own network namespace. nftables changes land in the container; the runner keeps its network throughout. `ubuntu:24.04` ships no init, so the container installs `systemd systemd-sysv` and `exec`s `/sbin/init` as PID 1 in the same command.
4. **Systemd's readiness is asserted before the package goes in.** `debian/postinst` only starts the services `if [ -d /run/systemd/system ]`, which only exists once systemd is truly running — so installing before that would "succeed" while starting nothing, and every check after it would report nothing running and call it a pass. A new step polls `systemctl is-system-running` until it reports `running` or `degraded` (never left at `offline`) before install proceeds.
5. **Every existing check is carried over**, adjusted to run inside the container via `docker exec` (root by default, `--user easywall` where the original used `sudo -u easywall` to drop privileges): installed layout and owners/modes, both services active, the web user reaching the core socket, the interface answering while the core config stays out of reach, and the version compiled in. Nothing was dropped.
6. A **container cleanup step** (`docker rm -f`, `if: always()`) tears the container down regardless of outcome.

No changes to `debian/`, `systemd/`, Go code, or `release.yml`. Both matrix architectures (`amd64`/`arm64`, `ubuntu-24.04`/`ubuntu-24.04-arm`) are preserved — `ubuntu:24.04` is multi-arch so the same container recipe works on both.

## Verification

- `actionlint` (via `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/build.yml`): clean except two pre-existing `SC2034` "unused loop variable `i`" style warnings that are present identically on `main` today — not introduced by this change.
- YAML parses cleanly; every `run:` block in the job extracted and checked with `bash -n` (all heredocs terminate correctly).
- **Docker itself was not available in this sandbox** (socket requires interactive `sudo`), so the container mechanism was validated locally with rootless **podman** instead, which uses the same OCI runtime primitives:
  - privileged container + `--cgroupns=host` + `/sys/fs/cgroup` mount boots systemd as PID 1
  - `systemctl is-system-running` moves from empty/`offline` to `degraded` within ~20s (never stuck at `offline`)
  - a real service (`openssh-server`) installs and reaches `active`
  - `docker exec -i CONTAINER bash -s <<'EOF' ... EOF` (the pattern used for the layout/services checks) round-trips correctly
  - `docker exec --user <user>` correctly drops privileges (used in place of `sudo -u <user>`)
- What only CI can prove: the actual easywall `.deb` installing and both `easywall-core`/`easywall-web` starting inside this container shape, end to end, on both `ubuntu-24.04` and `ubuntu-24.04-arm`. This PR's own CI run against `build.yml` is the first real test of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)