### PR TITLE
docs(claude): a test is verified by breaking the code, not by reading it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ Each of these cost a release. They are not style preferences.
 | **A generated file is rebuilt and diffed, never assumed** | Tailwind drops a rule silently and the build stays green — grep the built file |
 | **`-ldflags -X` writes to a `var`** | `CurrentVersion` was a `const`, so every release binary reported the literal in the source and the flag reported nothing |
 | **Plan larger changes first, and read the code in full** | Keyword-grepping produced confident answers about code that did not say what the grep suggested |
+| **A test is verified by breaking the code, not by reading it** | 2.12's reviews found seven tests that passed for the wrong reason — a sample equal to the shipped default, a fixture where the precedence rule carried the test, a key appended past a `[tls]` header into the wrong table, a recomputation with no guard. All seven were green, and all seven were found by mutating the implementation |
 | **A fix carries its documentation** | Both locales, the schema, the UI copy — or the next audit finds the mismatch you created |
 | **One source for the Go toolchain** | Five places disagreed for months; see [dependencies](docs-tech/dependencies.md) |
 


### PR DESCRIPTION
One row in `CLAUDE.md`'s rules table — the table of things that each cost a release.

During 2.12, task reviews found **seven tests that passed for the wrong reason**.
All seven were green when written, and reading the diff approved several of them.
Every one was caught by mutating the implementation and watching what did *not* go
red:

- a sample value equal to the shipped default, leaving `update_check` and
  `demo_mode` asserting nothing in the release's own mandated guard — the subtest
  stayed green with `applyEnv` mutated to never call `Set` at all
- a fixture where the new precedence rule silently carried the test instead of the
  code under test
- a fixture key appended past a trailing `[tls]` header, so it decoded as
  `tls.telemetry` and a **consent** test passed on a broken premise (twice, in two
  separate tasks)
- `Provenance()`'s recomputation — replacing it with a load-time cache left the
  whole suite green
- `provenanceFor` with `Env`/`Stored` swapped, and the marker template with its
  condition inverted — both survived the entire `internal/web` suite

The rule belongs beside the others in that table because it has the same shape: a
green build that proves less than it appears to, exactly like
*"a generated file is rebuilt and diffed, never assumed"* and *"verify UI by
rendering it, not by reading CSS"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)