### PR TITLE
chore(release): 2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [2.14.0] — 2026-09-02
 
 **The window shows that it is running.**
 
@@ -433,6 +433,7 @@ now* sits beside *Confirm* rather than being described in a sentence.
   charges every language 18px of empty tile whether anything wraps or not;
   this charges none, because a row is as tall as its tallest label
 
+[2.14.0]: https://github.com/jp1337/easywall/compare/v2.13.0...v2.14.0
 [2.13.0]: https://github.com/jp1337/easywall/compare/v2.12.0...v2.13.0
 [2.12.0]: https://github.com/jp1337/easywall/compare/v2.11.0...v2.12.0
 [2.11.0]: https://github.com/jp1337/easywall/compare/v2.10.0...v2.11.0
@@ -1332,7 +1333,7 @@ After explicit configuration the following ICMPv6 types are allowed additionally
 - easywall Firewall Core Part running as root user finished
 - The New easywall will be one part running as root and one part running as easywall user which has access to config files.
 
-[unreleased]: https://github.com/jp1337/easywall/compare/v2.13.0...HEAD
+[unreleased]: https://github.com/jp1337/easywall/compare/v2.14.0...HEAD
 [2.2.0]: https://github.com/jp1337/easywall/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/jp1337/easywall/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/jp1337/easywall/compare/v0.3.1...v2.0.0

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,31 @@
+easywall (2.14.0) unstable; urgency=medium
+
+  * Feat: the acceptance window is visible while it runs. Every apply reverts
+    itself after 120 seconds unless it is confirmed, and the interface showed
+    that with a static clock glyph and the word Open — two screenshots nine
+    seconds apart were pixel-identical. There is now a countdown at 40px on the
+    apply screen, a chip carrying the same number in the topbar of every other
+    page, and Roll back now beside Confirm. The number and the timer that fires
+    come from one instant, so they cannot disagree.
+  * Feat: CANCEL_ACCEPTANCE, the twentieth protocol command. It reaches the
+    Cancel that has existed since 2.7 and had no route to it. Rolling back
+    restores the last confirmed rule set — the state the operator already
+    approved — so it grants nothing that waiting out the window does not.
+  * Fix: a SIGTERM landing between an apply starting and its window opening was
+    discarded, and shutdown then waited out the whole window — past systemd's
+    TimeoutStopSec, after which SIGKILL left the unconfirmed rules live. That is
+    the failure the window exists to prevent.
+  * Fix: the window now opens before the rules reach the kernel, as
+    Acceptance.Start's own contract had always required. It used to open after
+    two file writes, during which the kernel held unconfirmed rules while the
+    interface reported no window at all.
+  * Fix: an operator rollback is recorded as one audit entry saying so, rather
+    than two of which the second claimed a timeout.
+  * Fix: the Add from catalogue button drew a solid block instead of an icon,
+    and had done since the catalogue shipped in 2.11.
+
+ -- JP <12394156+jp1337@users.noreply.github.com>  Wed, 02 Sep 2026 20:58:21 +0200
+
 easywall (2.13.0) unstable; urgency=medium
 
   * Feat: trusted_proxies, and EASYWALL_WEB_TRUSTED_PROXIES beside it. A list

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,7 +16,7 @@ timezone: Europe/Berlin
 # Shown as the badge in the sidebar. Must match shared.CurrentVersion in
 # internal/shared/version.go — TestDocsVersionMatchesRelease enforces that.
 # It was hardcoded in the layout as "v2.4" and drifted a patch release behind.
-version: "2.13.0"
+version: "2.14.0"
 
 tagline: "Your firewall. Your rules. No surprises."
 logo: /assets/img/icon.svg

--- a/docs/_docs/changelog.md
+++ b/docs/_docs/changelog.md
@@ -16,7 +16,7 @@ until you open them. This page is generated from
 which is the file GitHub and the release tooling read.
 
 <details open markdown="1">
-<summary><strong>Unreleased</strong> — The window shows that it is running</summary>
+<summary><strong>2.14.0</strong> · 2026-09-02 — The window shows that it is running</summary>
 
 Every apply reverts itself after 120 seconds unless it is confirmed — and for
 four releases the screen said so with a static clock glyph and the word *Open*.
@@ -93,7 +93,7 @@ now* sits beside *Confirm* rather than being described in a sentence.
   the stylesheet: whether text fits a box is not something a number in a CSS
   file can say
 
-[See everything changed since the last release](https://github.com/jp1337/easywall/compare/v2.13.0...HEAD)
+[See the code changes between 2.13.0 and 2.14.0](https://github.com/jp1337/easywall/compare/v2.13.0...v2.14.0)
 
 </details>
 

--- a/internal/shared/version.go
+++ b/internal/shared/version.go
@@ -26,7 +26,7 @@ import (
 // stylesheet URL never changed across an upgrade even though it is versioned
 // precisely so that it does. `easywall-core --version` prints this, so a build
 // can be checked rather than assumed.
-var CurrentVersion = "2.13.0"
+var CurrentVersion = "2.14.0"
 
 const (
 	// cacheMaxAge is how long a successful check is trusted.


### PR DESCRIPTION
The release commit, through a pull request because direct pushes to `main` are refused — a brand-new commit carries no passing checks, which is what the protection rule says.

Five files in the documented order: `CHANGELOG.md` cut to `[2.14.0]` with its link definition, `debian/changelog` (which `debian/rules` takes the package version from), `internal/shared/version.go` and `docs/_config.yml` agreeing at 2.14.0, and `docs/_docs/changelog.md` regenerated from the source rather than hand-edited.

The tag follows on the resulting `main` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)