### PR TITLE
fix(ci): let the systemd wait cover the install it depends on

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,15 +253,31 @@ jobs:
       # PID 1 and running — not once the container is merely "up". Installing
       # the package before this is confirmed would silently skip the coverage
       # this job exists for.
+      # This wait covers three things, not one: pulling ubuntu:24.04 on a cold
+      # runner, the container's own `apt-get install systemd` — it cannot exec
+      # what it has not installed yet — and only then systemd reaching PID 1.
+      # It allowed sixty seconds for all three and stopped fitting: every poll
+      # read `systemctl: executable file not found`, which does not mean
+      # "systemd never came up" but "apt had not got to it yet", and the loop
+      # could not tell those apart. So both are named, the budget covers the
+      # install, and a container that has already exited is not waited out for
+      # three minutes to be told what its logs said immediately.
       - name: Assert systemd is actually running before installing anything
         run: |
           set -euo pipefail
           state=""
-          for i in $(seq 1 60); do
+          for i in $(seq 1 180); do
+            if [ "$(docker inspect -f '{{.State.Running}}' easywall-test 2>/dev/null || echo false)" != "true" ]; then
+              echo "::error::the container exited before systemd came up — the install inside it failed"
+              docker logs easywall-test --tail 100 || true
+              exit 1
+            fi
             state=$(docker exec easywall-test systemctl is-system-running 2>/dev/null || true)
-            echo "systemd state: ${state:-<not answering yet>}"
             case "$state" in
-              running|degraded) break ;;
+              running|degraded) echo "systemd state: $state"; break ;;
+              ''|*'exec failed'*|*'not found'*)
+                echo "waiting (${i}s): systemd is not installed in the container yet" ;;
+              *) echo "systemd state: $state" ;;
             esac
             sleep 1
           done


### PR DESCRIPTION
The `Debian Package (amd64)` job has failed on every pull request since
2026-09-03 — #156 and #157 are both blocked by it, and neither caused it.
`arm64` passed only because its runner happened to be faster.

## What actually happens

The container is started with

```
apt-get update && apt-get install -y systemd systemd-sysv curl python3 && exec /sbin/init
```

so it cannot exec systemd before it has installed it. The readiness poll
began **0.6 s** after the container was created and allowed sixty seconds for
an image pull, that install, and systemd's boot together. All sixty attempts
read:

```
systemctl: executable file not found in $PATH
```

That is not *systemd never came up*. It is *apt had not reached it yet* — and
the loop could not distinguish them, so it reported the wrong one and gave up
while the container was still working.

## What this changes

| | |
|---|---|
| Budget | 60 s → 180 s, so it covers the install it waits on |
| Log | "not installed yet" and a real systemd state are now separate lines |
| Exited container | failed immediately with its logs, instead of waited out for three minutes |

**The assertion is unchanged.** Readiness is still proven *before* anything
installs the package — `debian/postinst` only starts the services when
`/run/systemd/system` exists, so a container where systemd never came up would
install the package, start nothing, and pass every check below it. That is the
coverage this job exists for, and it stays.

This job also gates the release, so 2.15 needs it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)