### PR TITLE
test(core): wait for the apply goroutine instead of sleeping at it

### DIFF
--- a/internal/core/daemon_test.go
+++ b/internal/core/daemon_test.go
@@ -458,8 +458,16 @@ func TestDaemonDispatch_ApplyRules_ReturnsSuccess(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for dispatch")
 	}
-	// Brief pause to let the async Apply goroutine start and finish
-	time.Sleep(50 * time.Millisecond)
+	// d.wg, not a sleep. The dispatch case adds to it before it starts the
+	// goroutine — "Tracked in d.wg so Stop waits for it" — so waiting on it
+	// waits for exactly this apply and nothing else.
+	//
+	// A sleep here was a hope, and it broke: DataDir is t.TempDir(), the apply
+	// writes into it, and 2.15 gave it two more writes on that path (the usage
+	// collect and the baseline reset). On a loaded runner the goroutine landed
+	// after the test returned and t.TempDir()'s RemoveAll failed with
+	// "directory not empty" — a docs-only pull request went red on it.
+	d.wg.Wait()
 }
 
 func TestDaemonDispatch_GetRules_Error(t *testing.T) {
@@ -574,9 +582,16 @@ func TestDaemonDispatch_ApplyRules_GoroutineError(t *testing.T) {
 	if !resp.Success {
 		t.Fatalf("dispatch CmdApplyRules should return Success: %s", resp.Error)
 	}
-	// Give the goroutine enough time to run Apply (which fails with nil conn)
-	// and reach slog.Error("apply error", ...)
-	time.Sleep(100 * time.Millisecond)
+	// d.wg, not a sleep. The dispatch case adds to it before it starts the
+	// goroutine — "Tracked in d.wg so Stop waits for it" — so waiting on it
+	// waits for exactly this apply and nothing else.
+	//
+	// A sleep here was a hope, and it broke: DataDir is t.TempDir(), the apply
+	// writes into it, and 2.15 gave it two more writes on that path (the usage
+	// collect and the baseline reset). On a loaded runner the goroutine landed
+	// after the test returned and t.TempDir()'s RemoveAll failed with
+	// "directory not empty" — a docs-only pull request went red on it.
+	d.wg.Wait()
 }
 
 // TestDaemonDispatch_ApplyRules_PanicRecovery exercises the recover() branch inside
@@ -596,8 +611,16 @@ func TestDaemonDispatch_ApplyRules_PanicRecovery(t *testing.T) {
 	if !resp.Success {
 		t.Fatalf("dispatch should return success immediately: %s", resp.Error)
 	}
-	// Wait for the goroutine to panic and recover
-	time.Sleep(100 * time.Millisecond)
+	// d.wg, not a sleep. The dispatch case adds to it before it starts the
+	// goroutine — "Tracked in d.wg so Stop waits for it" — so waiting on it
+	// waits for exactly this apply and nothing else.
+	//
+	// A sleep here was a hope, and it broke: DataDir is t.TempDir(), the apply
+	// writes into it, and 2.15 gave it two more writes on that path (the usage
+	// collect and the baseline reset). On a loaded runner the goroutine landed
+	// after the test returned and t.TempDir()'s RemoveAll failed with
+	// "directory not empty" — a docs-only pull request went red on it.
+	d.wg.Wait()
 }
 
 func TestLookupGroup_OpenError(t *testing.T) {


### PR DESCRIPTION
Found by #160 — a pull request that touches only `docs/_docs/roadmap.md` and
went red on `Integration tests (nftables / CAP_NET_ADMIN)`.

## What it was

```
--- FAIL: TestDaemonDispatch_ApplyRules_GoroutineError (0.15s)
    testing.go:1617: TempDir RemoveAll cleanup:
      unlinkat /tmp/TestDaemonDispatch_ApplyRules_GoroutineError.../data:
      directory not empty
```

Three tests dispatch `APPLY_RULES` and then **sleep** — 50 ms, 100 ms, 100 ms —
in place of waiting. `DataDir` is `t.TempDir()`, the apply goroutine writes
there, and 2.15 gave it two more writes on that path (the usage collect and the
baseline reset). The sleep was always a hope; the extra work widened the window
until a loaded runner lost the race and `RemoveAll` tripped over a file that
appeared mid-teardown.

## The fix

`d.wg.Wait()`. The dispatch case already adds to `d.wg` before it starts the
goroutine — *"Tracked in d.wg so Stop waits for it"* — so waiting on it waits
for exactly this apply and nothing else. **No production change.** The `Add`
precedes the `Wait` in program order, so this is not the zero-counter pairing
2.15 closed in the accept loop.

## Evidence

- 180 runs at `GOMAXPROCS=8` on a pinned cpu set, 12 processes in parallel: no failures.
- `go test ./internal/...`, `-race -count=3` on core, `go vet` under both tag sets, golangci-lint: clean.
- The suite is also faster: 250 ms of sleeping per run is gone.

The short 5–10 ms polling loops elsewhere in that file are a different shape
(socket readiness) and are already recorded as open; they are not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)