### PR TITLE
2.15.1 — Two ways a new installation could lock you out of its own host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,69 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.1] — 2026-09-07
+
+**Two ways a new installation could lock you out of its own host.**
+
+Reported from Discord: a VPS unreachable immediately after
+`docker compose up -d`, and still cutting SSH on every later `docker` start.
+The pasted ruleset carried the evidence for both causes —
+`tcp dport 22 ct state 0x8000000 jump sshbrute`, a conntrack state no packet
+ever has.
+
+### Fixed
+
+- **The conntrack state masks were byte-reversed, so three rules matched
+  nothing.** The kernel writes `ct state` into a register as a native `u32`;
+  all three masks in `internal/core/nftables.go` were written as
+  `[]byte{0x00, 0x00, 0x00, 0x06}` instead of `{0x06, 0x00, 0x00, 0x00}`, and
+  the kernel rendered them back as `ct state 0x2000000,0x4000000` — bits no
+  conntrack state sets. The worst of the three is
+  `ct state established,related accept`, the entire stateful half of the input
+  chain: without it a reply packet has no rule to match, so **an installation
+  with a live table had no working outbound connectivity at all** — no DNS, no
+  `apt update`, no version check — and applying the table dropped any SSH
+  session already open, because the only rules still matching were the
+  stateless `dport N accept` ones. The other two failed open: the
+  invalid-packet drop and the SSH brute-force meter both reported themselves
+  enabled and enforced nothing. Measured in a veth pair against an HTTP server:
+  `counter packets 0` and a failed request on the reversed rule, `packets 6`
+  and HTTP 200 on the corrected one, with a no-ruleset control returning 200.
+- **A test had written the defect down as the expected output.**
+  `nftables_semantics_test.go` asserted
+  `dport 2222 ct state 0x8000000 jump sshbrute` under a comment explaining that
+  "nft prints the mask rather than the name" — and both halves were wrong. `nft`
+  names every state it recognises, including for a bitwise-and plus a
+  not-equal-zero test, because that is how it compiles `ct state new` itself; it
+  printed raw hex here precisely because the mask was reversed. The assertion
+  was written from observed output rather than from intent, which is what let
+  this ship. It now asserts `ct state new`, and a new guard,
+  `TestIntegration_NoCtStateRendersAsARawMask`, fails on **any** hex-rendered ct
+  state in the table — the class, not the three instances.
+- **A host where nothing has ever been applied is no longer made to enforce an
+  empty rule set.** `RulesStore` initialises `rules.json` with `emptyState()`
+  and `Daemon.Start` restored it unconditionally, so the input chain came up at
+  `policy drop` with no port open: SSH closed, and the web interface whose
+  first-run wizard is the only thing that would have opened SSH closed with it.
+  `docker compose up -d` and `dpkg -i` both start the core before the operator
+  can open a single port. `RestoreCurrent`'s own contract rests on `Current`
+  being "a rule set that has already survived an acceptance window", which is
+  not true of one nobody has ever applied; `Firewall.everConfigured` now makes
+  that contract hold. A non-empty `Current` **or** a last-apply marker counts as
+  configured, so an operator who deliberately applied an empty set keeps it, and
+  an installation upgrading from an earlier release keeps filtering. Otherwise
+  the machine is left exactly as easywall found it and filtering starts at the
+  first deliberate apply — the one that has the acceptance window to undo it.
+  Recorded as a new audit action, `boot_not_configured`, amber.
+
+### Why it was not caught
+
+`docs/installation/docker.md` says to open `https://localhost:12227`, and
+loopback is accepted — so the documented first step works on the machine the
+software is developed on and fails on every remote host. Every count-based
+integration test stayed green throughout, because the rules were present in the
+table; they simply never fired.
+
 ## [2.15.0] — 2026-09-07
 
 **You can see it working.**
@@ -1425,7 +1488,8 @@ After explicit configuration the following ICMPv6 types are allowed additionally
 - easywall Firewall Core Part running as root user finished
 - The New easywall will be one part running as root and one part running as easywall user which has access to config files.
 
-[unreleased]: https://github.com/jp1337/easywall/compare/v2.15.0...HEAD
+[unreleased]: https://github.com/jp1337/easywall/compare/v2.15.1...HEAD
+[2.15.1]: https://github.com/jp1337/easywall/compare/v2.15.0...v2.15.1
 [2.15.0]: https://github.com/jp1337/easywall/compare/v2.14.0...v2.15.0
 [2.2.0]: https://github.com/jp1337/easywall/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/jp1337/easywall/compare/v2.0.0...v2.1.0

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+easywall (2.15.1) unstable; urgency=high
+
+  * Fix: the conntrack state masks were written in the wrong byte order, so
+    the `established,related` accept rule in the input chain matched nothing.
+    An installation with a live table could not complete a single outbound
+    connection, and applying the rules dropped whatever SSH session was
+    already open. The invalid-packet drop and the SSH brute-force meter were
+    the same mistake failing open. Reported after a VPS was cut off
+    immediately following `docker compose up -d`.
+  * Fix: a host where nothing has ever been applied is no longer made to
+    enforce the empty rule set a new installation ships with. That closed
+    every port, including SSH and the web interface whose first-run wizard is
+    the only thing that opens them. Filtering now starts at the first
+    deliberate apply, which has the acceptance window to undo it.
+
+ -- JP <12394156+jp1337@users.noreply.github.com>  Mon, 07 Sep 2026 22:54:41 +0200
+
 easywall (2.15.0) unstable; urgency=medium
 
   * Feat: every port rule carries a kernel packet counter and a stable id, so

--- a/docs-tech/carried-forward.md
+++ b/docs-tech/carried-forward.md
@@ -16,6 +16,16 @@ the sentence.
 Not published — this directory sits outside `docs/`, which is the entire Jekyll
 source. See `TestTheTechnicalDocsAreNotPublished`.
 
+# From 2.15.1
+
+Found while analysing the Discord lockout report, proven against `main` before
+the hotfix branch existed, and unrelated to the two defects it fixes.
+
+| | |
+|---|---|
+| **The landing page names three classes the stylesheet does not define** | `docs/index.md` carries `.docs-landstrip`, `.docs-cardgrid` and `.docs-card`; `web/src/docs.css` defines none of them, and Tailwind generates none. The section renders as unstyled prose. `TestTemplateClassesExistInStylesheet` covers `web/templates/` and `app.js` only, so nothing in the suite looks at markup under `docs/`. Belongs with 2.16, which is already rewriting `docs.css` |
+| **`docs/installation/docker.md` tells a remote operator to open `https://localhost:12227`** | The one instruction that only ever works on the machine easywall is developed on. It is why both defects in this release went unseen: loopback is accepted, so the documented first step succeeds locally and fails on every VPS. The fix is a documentation change to a page 2.16 is not otherwise touching, and it wants the first-run flow rewritten around a remote host rather than one sentence changed |
+
 # From 2.15
 
 Two layout defects found while verifying the *Last used* column, both proven

--- a/docs-tech/invariants.md
+++ b/docs-tech/invariants.md
@@ -126,6 +126,25 @@ The background is in [dependencies](dependencies.md).
 | `TestScreenshotsAreTakenAboveTheTwoColumnBreakpoint` | `SHOT_VIEWPORT` in `scripts/ui-check.mjs` is wider than the `max-width` at which `.page-grid` drops its context column | the screenshots were taken at 1440px against a breakpoint of 1570px from 2.11 to 2.13, so every figure in `docs/` showed the narrow fallback — aside cards stacked under the table rather than beside it. The two numbers live in different files and neither is near the other: lowering the breakpoint and narrowing the viewport re-create it independently |
 | `TestScreenshotsGrowTheWindowInsteadOfCapturingBeyondIt` | `shoot()` resizes the viewport to the document instead of passing `fullPage`, for as long as `.sidebar` is `position: fixed` | a fixed element in a fullPage capture stays laid out against the window it was rendered in. The sidebar therefore stopped at 900px in every taller image, with the language switch, the theme toggle and *Logout* floating in the middle of a column that then went blank — 22 of the 34 files in `docs/assets/img/screens/` shipped that way |
 
+## The rules say what they mean
+
+A rule that is present in the table and matches nothing is invisible to every
+count-based test in the repository, and 2.15.1 shipped three of them for five
+releases.
+
+| Test | Protects | What it would have shipped |
+|---|---|---|
+| `TestCtStateMaskIsTheByteOrderTheKernelCompares` | the ct state mask is a native `u32`, so the kernel compares against the bits the name means | the mask was written `[]byte{0x00, 0x00, 0x00, 0x06}` and the kernel read `0x06000000`. The expected bytes in the test come from `nft --debug=netlink`, not from the implementation, so reversing `ctStateMask` turns it red rather than agreeing with itself |
+| `TestIntegration_EstablishedTrafficIsAcceptedByName` | `ct state established,related accept` renders under that name | it rendered as `ct state 0x2000000,0x4000000` and matched no packet ever sent — the whole stateful half of the input chain. An installation with a live table could complete no outbound connection at all, and applying the rules dropped the SSH session that was already open |
+| `TestIntegration_NoCtStateRendersAsARawMask` | **no** ct state anywhere in the table renders as hex | the class rather than the three instances. `nft` names every state it recognises, so a raw mask means bits no conntrack state sets — including on a rule added after this test was written |
+| `TestRulesIsEmptyCountsEveryField` | `shared.Rules.IsEmpty` counts every field of the struct, by reflection | a seventh rule set added and forgotten makes a configured host look unconfigured, and its stored rules quietly stop being enforced at boot |
+| `TestRestoreCurrent_DoesNotEnforceAnInstallationNobodyConfigured` | a host where nothing was ever applied is left alone at boot | `RulesStore` initialises `rules.json` with `emptyState()` and the boot restore installed it: `policy drop` with no port open, so SSH and the interface that would have opened SSH both closed. `docker compose up -d` and `dpkg -i` both reach it before the operator can open anything |
+| `TestRestoreCurrent_EnforcesAnEmptySetSomebodyApplied` | the guard above reads "never configured", not "empty" | an operator who deliberately applied an empty set, and an installation upgrading from before the guard existed, would both stop being restored at boot — the one direction that silently stops a firewall |
+
+The shape worth copying: **assert the kernel's own rendering, by name.** Every
+`ruleCount` assertion in this package was green throughout, because a rule that
+matches nothing is still a rule.
+
 Tailwind drops rules silently and the build stays green. A stylesheet test is a
 poor substitute for looking at the page — but it catches the class of failure
 where the page looks right on the machine that has the old file cached.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,7 +16,7 @@ timezone: Europe/Berlin
 # Shown as the badge in the sidebar. Must match shared.CurrentVersion in
 # internal/shared/version.go — TestDocsVersionMatchesRelease enforces that.
 # It was hardcoded in the layout as "v2.4" and drifted a patch release behind.
-version: "2.15.0"
+version: "2.15.1"
 
 tagline: "Your firewall. Your rules. No surprises."
 logo: /assets/img/icon.svg

--- a/docs/_docs/changelog.md
+++ b/docs/_docs/changelog.md
@@ -16,6 +16,72 @@ until you open them. This page is generated from
 which is the file GitHub and the release tooling read.
 
 <details open markdown="1">
+<summary><strong>2.15.1</strong> · 2026-09-07 — Two ways a new installation could lock you out of its own host</summary>
+
+Reported from Discord: a VPS unreachable immediately after
+`docker compose up -d`, and still cutting SSH on every later `docker` start.
+The pasted ruleset carried the evidence for both causes —
+`tcp dport 22 ct state 0x8000000 jump sshbrute`, a conntrack state no packet
+ever has.
+
+### Fixed
+
+- **The conntrack state masks were byte-reversed, so three rules matched
+  nothing.** The kernel writes `ct state` into a register as a native `u32`;
+  all three masks in `internal/core/nftables.go` were written as
+  `[]byte{0x00, 0x00, 0x00, 0x06}` instead of `{0x06, 0x00, 0x00, 0x00}`, and
+  the kernel rendered them back as `ct state 0x2000000,0x4000000` — bits no
+  conntrack state sets. The worst of the three is
+  `ct state established,related accept`, the entire stateful half of the input
+  chain: without it a reply packet has no rule to match, so **an installation
+  with a live table had no working outbound connectivity at all** — no DNS, no
+  `apt update`, no version check — and applying the table dropped any SSH
+  session already open, because the only rules still matching were the
+  stateless `dport N accept` ones. The other two failed open: the
+  invalid-packet drop and the SSH brute-force meter both reported themselves
+  enabled and enforced nothing. Measured in a veth pair against an HTTP server:
+  `counter packets 0` and a failed request on the reversed rule, `packets 6`
+  and HTTP 200 on the corrected one, with a no-ruleset control returning 200.
+- **A test had written the defect down as the expected output.**
+  `nftables_semantics_test.go` asserted
+  `dport 2222 ct state 0x8000000 jump sshbrute` under a comment explaining that
+  "nft prints the mask rather than the name" — and both halves were wrong. `nft`
+  names every state it recognises, including for a bitwise-and plus a
+  not-equal-zero test, because that is how it compiles `ct state new` itself; it
+  printed raw hex here precisely because the mask was reversed. The assertion
+  was written from observed output rather than from intent, which is what let
+  this ship. It now asserts `ct state new`, and a new guard,
+  `TestIntegration_NoCtStateRendersAsARawMask`, fails on **any** hex-rendered ct
+  state in the table — the class, not the three instances.
+- **A host where nothing has ever been applied is no longer made to enforce an
+  empty rule set.** `RulesStore` initialises `rules.json` with `emptyState()`
+  and `Daemon.Start` restored it unconditionally, so the input chain came up at
+  `policy drop` with no port open: SSH closed, and the web interface whose
+  first-run wizard is the only thing that would have opened SSH closed with it.
+  `docker compose up -d` and `dpkg -i` both start the core before the operator
+  can open a single port. `RestoreCurrent`'s own contract rests on `Current`
+  being "a rule set that has already survived an acceptance window", which is
+  not true of one nobody has ever applied; `Firewall.everConfigured` now makes
+  that contract hold. A non-empty `Current` **or** a last-apply marker counts as
+  configured, so an operator who deliberately applied an empty set keeps it, and
+  an installation upgrading from an earlier release keeps filtering. Otherwise
+  the machine is left exactly as easywall found it and filtering starts at the
+  first deliberate apply — the one that has the acceptance window to undo it.
+  Recorded as a new audit action, `boot_not_configured`, amber.
+
+### Why it was not caught
+
+`docs/installation/docker.md` says to open `https://localhost:12227`, and
+loopback is accepted — so the documented first step works on the machine the
+software is developed on and fails on every remote host. Every count-based
+integration test stayed green throughout, because the rules were present in the
+table; they simply never fired.
+
+[See the code changes between 2.15.0 and 2.15.1](https://github.com/jp1337/easywall/compare/v2.15.0...v2.15.1)
+
+</details>
+
+<details markdown="1">
 <summary><strong>2.15.0</strong> · 2026-09-07 — You can see it working</summary>
 
 An open port nobody uses is the most common avoidable exposure on a hobby

--- a/docs/_docs/features/audit-log.md
+++ b/docs/_docs/features/audit-log.md
@@ -15,7 +15,7 @@ on disk keeps everything.
   <figcaption>The filter matches the wording on screen as well as the identifier stored on disk.</figcaption>
 </figure>
 
-## Only 10 entries carry colour
+## Only 11 entries carry colour
 
 Colour outside the accent family always means firewall state — green live, amber
 unconfirmed, red rolled back. If a merely informational event were tinted too, a
@@ -29,6 +29,7 @@ coloured tag would stop meaning anything.
 | 🔴 | `apply_failed` | Apply failed | The rules could not be pushed to the kernel |
 | 🔴 | `rollback_failed` | Rollback failed | The worst outcome there is: the new rules did not take **and** the old ones did not come back |
 | 🟢 | `boot_enforced` | Rules restored at startup | The stored rules were back in the kernel before anything else started |
+| 🟠 | `boot_not_configured` | Not filtering — nothing configured yet | The daemon started on a host where nothing has ever been applied, and left the machine exactly as it found it. Enforcing the empty rule set a new installation ships with would close every port, including SSH and the interface whose first-run wizard is the only thing that opens them. Filtering starts at your first apply, which has the acceptance window to undo it |
 | 🔴 | `boot_enforce_failed` | Rules could not be restored at startup | The machine came up and is not filtering — nothing on this list is worse. Also written when the panic marker cannot be read at all, when panic mode was engaged from the console while the restore was still writing, and whenever a panic teardown itself failed and the machine may still be filtering behind a marker that says it is not. The detail says which |
 | 🔴 | `panic_engaged` | Panic mode engaged | A human at the console took the firewall down on purpose. Deliberate does not make it neutral: the machine is unfiltered either way |
 | 🟢 | `panic_resumed` | Panic mode ended | The console put the firewall back to filtering |

--- a/internal/core/daemon_dispatch_test.go
+++ b/internal/core/daemon_dispatch_test.go
@@ -516,6 +516,8 @@ func TestDaemonDispatch_ApplyDoesNotRaceWithASettingsSave(t *testing.T) {
 func TestDispatch_PanicEngagesAndResumeClears(t *testing.T) {
 	cfg := newTestConfig(t)
 	fw := newTestFirewall(t, cfg)
+	// RESUME restores, and a restore only reaches nftables on a configured host.
+	configureTestFirewall(t, fw)
 	d := &Daemon{cfg: cfg, firewall: fw, quit: make(chan struct{})}
 	defer d.Stop()
 

--- a/internal/core/daemon_test.go
+++ b/internal/core/daemon_test.go
@@ -33,6 +33,27 @@ func newTestConfig(t *testing.T) *Config {
 }
 
 // newTestFirewall creates a Firewall with a stub NftablesManager for dispatch tests.
+// configureTestFirewall gives a test firewall the one thing RestoreCurrent now
+// requires before it will write anything: evidence that this installation has
+// ever been configured.
+//
+// Deliberately a separate call rather than something newTestFirewall does for
+// every caller. The distinction it draws — a host somebody has configured, and a
+// host where nothing has ever been applied — is the whole point of
+// Firewall.everConfigured, and a helper that quietly made every test look
+// configured would hide the case that produced it.
+func configureTestFirewall(t *testing.T, fw *Firewall) {
+	t.Helper()
+	if err := fw.rules.SaveStaged("tcp", []shared.PortRule{
+		{Port: "22", Description: "SSH", SSH: true},
+	}); err != nil {
+		t.Fatalf("stage a rule: %v", err)
+	}
+	if err := fw.rules.PromoteStaged(); err != nil {
+		t.Fatalf("promote it into Current: %v", err)
+	}
+}
+
 func newTestFirewall(t *testing.T, cfg *Config) *Firewall {
 	t.Helper()
 	store, err := NewRulesStore(cfg.RulesPath())
@@ -878,6 +899,8 @@ func waitForSocket(t *testing.T, path string) {
 func TestDaemonStart_RestoresAtStartup(t *testing.T) {
 	cfg := newTestConfig(t)
 	fw := newTestFirewall(t, cfg)
+	// A restore only has something to put back on a host somebody configured.
+	configureTestFirewall(t, fw)
 	d := &Daemon{cfg: cfg, firewall: fw, quit: make(chan struct{})}
 
 	startTestDaemon(t, d)
@@ -906,6 +929,7 @@ func TestDaemonStart_RestoresAtStartup(t *testing.T) {
 func TestDaemonStart_NoCommandIsServedBeforeTheRestoreHasRun(t *testing.T) {
 	cfg := newTestConfig(t)
 	fw := newTestFirewall(t, cfg)
+	configureTestFirewall(t, fw)
 	d := &Daemon{cfg: cfg, firewall: fw, quit: make(chan struct{})}
 
 	startTestDaemon(t, d)

--- a/internal/core/dockerreconcile_test.go
+++ b/internal/core/dockerreconcile_test.go
@@ -95,6 +95,7 @@ func TestReconcileDockerBridges_RestoresOnceWhenABridgeAppears(t *testing.T) {
 	cfg.Docker.Enabled = true
 	cfg.Docker.AllowBridgeNetworks = true
 	fw := newTestFirewall(t, cfg)
+	configureTestFirewall(t, fw)
 	fw.bootBridges = nil // boot saw nothing
 	fw.reconcilePoll = 10 * time.Millisecond
 	fw.reconcileWait = 2 * time.Second

--- a/internal/core/firewall_integration_test.go
+++ b/internal/core/firewall_integration_test.go
@@ -621,6 +621,10 @@ func TestIntegration_AppliedConfigIsRecordedWhereverTheKernelIsWritten(t *testin
 		t.Fatalf("a fresh data directory already has a snapshot: %v", err)
 	}
 
+	// An upgrade is a configured host by definition, and RestoreCurrent only
+	// writes on one — see TestRestoreCurrent_DoesNotEnforceAnInstallationNobodyConfigured.
+	configureTestFirewall(t, fw)
+
 	// The restore path, which is what an upgrade to 2.10 runs at the first
 	// service start.
 	if err := fw.RestoreCurrent(RestoreReasonBoot); err != nil {

--- a/internal/core/nftables.go
+++ b/internal/core/nftables.go
@@ -809,6 +809,52 @@ func (m *NftablesManager) addLoopbackAccept(t *nftables.Table, c *nftables.Chain
 	})
 }
 
+// ── Conntrack state matching ────────────────────────────────────────────────
+//
+// The kernel writes ct state into a register as a **native** u32, so the mask
+// a bitwise expression compares it against has to be in native byte order too.
+// nft's own code generation is the reference:
+//
+//	$ nft --debug=netlink -c -f - <<<'... ct state established,related accept ...'
+//	[ bitwise reg 1 = ( reg 1 & 0x00000006 ) ^ 0x00000000 ]
+//
+// All three masks in this file were written byte-reversed instead, as
+// []byte{0x00, 0x00, 0x00, 0x06}. The kernel renders that back as
+// `ct state 0x2000000,0x4000000` — bits no conntrack state ever sets — so the
+// rule matched nothing at all, silently, while `nft list ruleset` showed a rule
+// that looked present.
+//
+// What the established/related one cost, which is the whole input chain's
+// stateful half: a reply packet had no rule to match, so an installation with a
+// live table could not complete a single outbound connection — no DNS, no
+// `apt update`, no version check — and applying the table dropped whatever SSH
+// session was already open, because the only rules still matching were the
+// stateless `dport N accept` ones. Measured in a veth pair against an HTTP
+// server: 0 packets on the reversed rule and 6 on the corrected one, for the
+// same request. addInvalidPacketDrop and addSSHBruteForce were the same
+// mistake failing open — two protection modules that reported themselves on
+// and enforced nothing.
+//
+// binaryutil.NativeEndian is what the rest of this file already uses for a
+// register-width constant (see addAnycastDrop); these three were the outliers.
+const (
+	ctStateInvalid     = 0x01
+	ctStateEstablished = 0x02
+	ctStateRelated     = 0x04
+	ctStateNew         = 0x08
+)
+
+// ctStateMask returns the register mask that matches any of the given ct state
+// bits, in the byte order the kernel actually compares against.
+func ctStateMask(bits uint32) []byte {
+	return binaryutil.NativeEndian.PutUint32(bits)
+}
+
+// ctStateNoMatch is the zero a masked ct state is compared against. Byte order
+// does not enter into it — every byte is zero — so it is named rather than
+// repeated as a literal beside three masks where order is the whole point.
+var ctStateNoMatch = []byte{0x00, 0x00, 0x00, 0x00}
+
 func (m *NftablesManager) addEstablishedAccept(t *nftables.Table, c *nftables.Chain) {
 	m.conn.AddRule(&nftables.Rule{
 		Table: t,
@@ -819,10 +865,10 @@ func (m *NftablesManager) addEstablishedAccept(t *nftables.Table, c *nftables.Ch
 				SourceRegister: 1,
 				DestRegister:   1,
 				Len:            4,
-				Mask:           []byte{0x00, 0x00, 0x00, 0x06}, // ESTABLISHED | RELATED
-				Xor:            []byte{0x00, 0x00, 0x00, 0x00},
+				Mask:           ctStateMask(ctStateEstablished | ctStateRelated),
+				Xor:            ctStateNoMatch,
 			},
-			&expr.Cmp{Op: expr.CmpOpNeq, Register: 1, Data: []byte{0x00, 0x00, 0x00, 0x00}},
+			&expr.Cmp{Op: expr.CmpOpNeq, Register: 1, Data: ctStateNoMatch},
 			&expr.Verdict{Kind: expr.VerdictAccept},
 		},
 	})
@@ -893,10 +939,10 @@ func (m *NftablesManager) addInvalidPacketDrop(t *nftables.Table, c *nftables.Ch
 			SourceRegister: 1,
 			DestRegister:   1,
 			Len:            4,
-			Mask:           []byte{0x00, 0x00, 0x00, 0x01}, // INVALID state
-			Xor:            []byte{0x00, 0x00, 0x00, 0x00},
+			Mask:           ctStateMask(ctStateInvalid),
+			Xor:            ctStateNoMatch,
 		},
-		&expr.Cmp{Op: expr.CmpOpNeq, Register: 1, Data: []byte{0x00, 0x00, 0x00, 0x00}},
+		&expr.Cmp{Op: expr.CmpOpNeq, Register: 1, Data: ctStateNoMatch},
 	}
 	m.addFiltered(t, c, match, &expr.Verdict{Kind: expr.VerdictDrop},
 		logSpec{enabled: opts.InvalidPacketsLog, prefix: logPrefixInvalid})
@@ -1272,10 +1318,10 @@ func (m *NftablesManager) addSSHBruteForce(t *nftables.Table, c *nftables.Chain,
 					SourceRegister: 1,
 					DestRegister:   1,
 					Len:            4,
-					Mask:           []byte{0x00, 0x00, 0x00, 0x08}, // NEW state
-					Xor:            []byte{0x00, 0x00, 0x00, 0x00},
+					Mask:           ctStateMask(ctStateNew),
+					Xor:            ctStateNoMatch,
 				},
-				&expr.Cmp{Op: expr.CmpOpNeq, Register: 1, Data: []byte{0x00, 0x00, 0x00, 0x00}},
+				&expr.Cmp{Op: expr.CmpOpNeq, Register: 1, Data: ctStateNoMatch},
 				&expr.Verdict{Kind: expr.VerdictJump, Chain: "sshbrute"},
 			),
 		})

--- a/internal/core/nftables_ctstate_test.go
+++ b/internal/core/nftables_ctstate_test.go
@@ -1,0 +1,90 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/google/nftables/binaryutil"
+)
+
+// The ct state mask has to be in the byte order the kernel compares against,
+// and for a long time none of the three in nftables.go was.
+//
+// The expected bytes below are not derived from ctStateMask — they are what nft
+// itself emits, read off its own code generator:
+//
+//	$ nft --debug=netlink -c -f - <<'NFT'
+//	table inet t { chain c { type filter hook input priority filter; policy drop;
+//	  ct state established,related accept
+//	  tcp dport 22 ct state new accept } }
+//	NFT
+//	[ bitwise reg 1 = ( reg 1 & 0x00000006 ) ^ 0x00000000 ]
+//	[ bitwise reg 1 = ( reg 1 & 0x00000008 ) ^ 0x00000000 ]
+//
+// Written the other way round the kernel renders the rule as
+// `ct state 0x2000000,0x4000000` and it matches no packet ever sent. That is not
+// a theory: loaded into a veth pair against an HTTP server, the reversed
+// established/related rule finished the run with `counter packets 0` and the
+// request failed, while the corrected one reported `packets 6` and the same
+// request returned 200.
+//
+// Verify this test by mutation, not by reading it: swap ctStateMask for
+// binaryutil.BigEndian.PutUint32 and every case below must go red.
+func TestCtStateMaskIsTheByteOrderTheKernelCompares(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		bits uint32
+		want []byte
+	}{
+		{"established|related", ctStateEstablished | ctStateRelated, []byte{0x06, 0x00, 0x00, 0x00}},
+		{"new", ctStateNew, []byte{0x08, 0x00, 0x00, 0x00}},
+		{"invalid", ctStateInvalid, []byte{0x01, 0x00, 0x00, 0x00}},
+	} {
+		got := ctStateMask(tc.bits)
+		if len(got) != 4 {
+			t.Fatalf("%s: mask is %d bytes, the register compare is 4", tc.name, len(got))
+		}
+		for i := range tc.want {
+			if got[i] != tc.want[i] {
+				t.Errorf("%s: ctStateMask(%#x) = % x, want % x\n"+
+					"  reversed, the kernel reads bits no conntrack state sets and the rule "+
+					"matches nothing — for established|related that is every reply packet "+
+					"on the machine", tc.name, tc.bits, got, tc.want)
+				break
+			}
+		}
+	}
+}
+
+// The state bits themselves, against the values nft's own ct_state_tbl carries.
+// A mask in the right byte order over the wrong bit is the same defect one step
+// along, and it would render as a plausible-looking `ct state new` on a rule
+// that was supposed to say `established`.
+func TestCtStateBitsMatchConntrack(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		got  uint32
+		want uint32
+	}{
+		{"invalid", ctStateInvalid, 0x01},
+		{"established", ctStateEstablished, 0x02},
+		{"related", ctStateRelated, 0x04},
+		{"new", ctStateNew, 0x08},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("ct state %s is %#x, conntrack sets %#x", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+// ctStateNoMatch is compared against a masked register, so it must be the same
+// width as the mask. A short slice here is a silent no-match on every ct rule.
+func TestCtStateNoMatchIsRegisterWidth(t *testing.T) {
+	if len(ctStateNoMatch) != len(binaryutil.NativeEndian.PutUint32(0)) {
+		t.Errorf("ctStateNoMatch is %d bytes, the masked register is 4", len(ctStateNoMatch))
+	}
+	for i, b := range ctStateNoMatch {
+		if b != 0 {
+			t.Errorf("ctStateNoMatch[%d] = %#x, want 0", i, b)
+		}
+	}
+}

--- a/internal/core/nftables_semantics_test.go
+++ b/internal/core/nftables_semantics_test.go
@@ -4,6 +4,7 @@ package core
 
 import (
 	"os/exec"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -488,9 +489,16 @@ func TestIntegration_SSHFlaggedPort_IsMeteredAndReachable(t *testing.T) {
 	}
 
 	rs := ruleset(t)
-	// 0x8000000 is NEW. nft prints the mask rather than the name because the
-	// match is built as a bitwise-and plus a not-equal-zero test.
-	mustContain(t, rs, "dport 2222 ct state 0x8000000 jump sshbrute",
+	// `ct state new`, spelled out. This assertion used to read
+	// "dport 2222 ct state 0x8000000 jump sshbrute", with a comment explaining
+	// that "nft prints the mask rather than the name" — and both halves were
+	// wrong. nft prints the name perfectly well for a bitwise-and plus a
+	// not-equal-zero test, because that is exactly how it compiles `ct state
+	// new` itself. It printed a raw hex value here because the mask was written
+	// byte-reversed and 0x8000000 is a bit no conntrack state sets, so the jump
+	// never once fired. The test was written from the observed output instead of
+	// from the intent, which is what let it ship for five releases.
+	mustContain(t, rs, "dport 2222 ct state new jump sshbrute",
 		"a new connection to the flagged port must go through the rate limiter")
 	mustAcceptPort(t, "dport 2222", "and the port still has to be open")
 	mustContain(t, rs, "chain sshbrute",
@@ -811,4 +819,60 @@ func TestIntegration_CustomRules_OrdinaryOnesStillApply(t *testing.T) {
 	mustContain(t, rs, "ip saddr 192.0.2.50 tcp dport 9100 accept", "a custom rule must reach the kernel")
 	mustContain(t, rs, "8080", "a set in a custom rule must survive")
 	mustNotContain(t, rs, "monitoring only", "a comment is not a rule")
+}
+
+// ---------------------------------------------------------------------------
+// Conntrack state
+// ---------------------------------------------------------------------------
+
+// The rule that lets a reply packet back in, asserted by the name the kernel
+// gives it rather than by whatever it happens to print.
+//
+// This is the assertion whose absence let a byte-reversed mask ship: the input
+// chain's stateful half matched nothing, so an installation with a live table
+// could not finish a single outbound connection — no DNS, no `apt update`, no
+// version check — and applying the table dropped whatever SSH session was
+// already open. Every count-based test in this package stayed green throughout,
+// because the rule was present; it simply never fired.
+func TestIntegration_EstablishedTrafficIsAcceptedByName(t *testing.T) {
+	m := newIntegrationManager(t)
+	applyEmpty(t, m, shared.FirewallOptions{})
+
+	mustContain(t, ruleset(t), "ct state established,related accept",
+		"a reply packet has no other rule to match; without this the machine has no "+
+			"outbound connectivity at all and an open SSH session dies on the next packet")
+}
+
+// The invalid-packet module, same shape. It failed open rather than closed,
+// which is why nobody saw it: a protection module reporting itself on and
+// enforcing nothing looks exactly like a quiet network.
+func TestIntegration_InvalidPacketDropSaysInvalid(t *testing.T) {
+	m := newIntegrationManager(t)
+	applyEmpty(t, m, shared.FirewallOptions{InvalidPackets: true})
+
+	mustContain(t, ruleset(t), "ct state invalid",
+		"the module is switched on, so the rule has to match the state it names")
+}
+
+// And the class, not just the three instances.
+//
+// nft renders a ct state it recognises by name — `established,related`, `new`,
+// `invalid`. It falls back to a raw hex value only when the mask holds bits no
+// conntrack state sets, which is the signature of a mask written in the wrong
+// byte order. So a hex ct state anywhere in the table is a defect whatever rule
+// carries it, including one added after this test was written.
+func TestIntegration_NoCtStateRendersAsARawMask(t *testing.T) {
+	m := newIntegrationManager(t)
+	applyEmpty(t, m, shared.FirewallOptions{
+		InvalidPackets: true,
+		SSHBruteForce:  true,
+	})
+
+	raw := regexp.MustCompile(`ct state 0x[0-9a-f]+`)
+	if found := raw.FindAllString(ruleset(t), -1); len(found) > 0 {
+		t.Errorf("the table holds %d ct state match(es) the kernel cannot name: %v\n"+
+			"  nft names every state it recognises, so a raw mask means bits no conntrack "+
+			"state sets — the rule is in the table and matches nothing\n--- ruleset ---\n%s",
+			len(found), found, ruleset(t))
+	}
 }

--- a/internal/core/restore.go
+++ b/internal/core/restore.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+
+	"github.com/jp1337/easywall/internal/shared"
 )
 
 // Why the reason a restore happened is a constant and not free text: it reaches
@@ -70,6 +72,38 @@ func (f *Firewall) RestoreCurrent(reason string) error {
 		WriteAuditLog(f.cfg.AuditLogPath(), "boot_enforce_failed", "all",
 			fmt.Sprintf("%s: %s", reason, err.Error()), "core")
 		return fmt.Errorf("get rules: %w", err)
+	}
+
+	// Nothing has ever been applied here, so there is nothing to put back.
+	//
+	// RestoreCurrent's contract above rests on Current being "a rule set that has
+	// already survived an acceptance window". On a host that has never been
+	// configured that is not true: RulesStore initialises rules.json with
+	// emptyState(), and enforcing an empty set means an input chain at policy
+	// drop with no port open at all — SSH closed, and the web interface that
+	// would have opened it closed with it. The first-run wizard cannot be
+	// reached to fix it, because it is behind the door it exists to unlock.
+	//
+	// That is not theoretical. `docker compose up -d` and `dpkg -i` both start
+	// the core before the operator can open a single port, and a report of a VPS
+	// cut off "immediately after docker compose up -d" is what found it. It went
+	// unseen because the documented first step is to open https://localhost:12227,
+	// and loopback is accepted.
+	//
+	// So the machine is left exactly as it was one second before easywall was
+	// installed, and filtering starts at the first deliberate apply — which has
+	// the acceptance window to undo it. applyFirstRunChoices already reasons this
+	// way in as many words: rules are staged, never applied, because "the first
+	// run is the worst moment to make an exception".
+	if !f.everConfigured(state) {
+		WriteAuditLog(f.cfg.AuditLogPath(), "boot_not_configured", "all", reason, "core")
+		slog.Warn("nothing has ever been applied on this installation, so this machine "+
+			"is not filtering: the stored rule set is empty, and enforcing an empty set "+
+			"at policy drop would close SSH and the web interface with it. Open the web "+
+			"interface and finish the first run — the first apply is what starts "+
+			"filtering, and it has the acceptance window to undo it",
+			"reason", reason)
+		return nil
 	}
 
 	// What this apply is about to bake in, so reconcileDockerBridges can tell
@@ -165,6 +199,32 @@ func (f *Firewall) RestoreCurrent(reason string) error {
 	WriteAuditLog(f.cfg.AuditLogPath(), "boot_enforced", "all", reason, "core")
 	slog.Info("the stored rules are in force again", "reason", reason)
 	return nil
+}
+
+// everConfigured reports whether this installation has ever had a rule set put
+// into the kernel on purpose.
+//
+// Two signals, because neither alone covers every installation:
+//
+//   - A non-empty Current. Somebody wrote rules and applied them; only
+//     PromoteStaged puts anything there, and only an apply runs it.
+//   - A last-apply marker on disk. This is what keeps an operator who
+//     deliberately applied an *empty* rule set — which is their choice, made
+//     through an acceptance window that let them undo it — enforcing that empty
+//     set across a reboot. It also covers an installation upgrading from a
+//     release before this check existed, where Current may legitimately be empty
+//     and the machine has been filtering for months.
+//
+// The failure mode to avoid is the second one reading false on a configured
+// host: that would quietly stop enforcing rules somebody wrote. Both signals
+// therefore say "configured", and only their absence together says otherwise.
+func (f *Firewall) everConfigured(state shared.RulesState) bool {
+	if !state.Current.IsEmpty() {
+		return true
+	}
+	f.lastApplyMu.Lock()
+	defer f.lastApplyMu.Unlock()
+	return !f.lastApply.IsZero()
 }
 
 // panicLandedDuringWrite tears the table down again when panic mode was engaged

--- a/internal/core/restore_test.go
+++ b/internal/core/restore_test.go
@@ -72,6 +72,10 @@ func TestRestoreCurrent_SkipsWhenPanicIsEngaged(t *testing.T) {
 func TestRestoreCurrent_AttemptsAndRecordsFailure(t *testing.T) {
 	cfg := newTestConfig(t)
 	fw := newTestFirewall(t, cfg)
+	// The restore reaches nftables only on a host that has been configured;
+	// an installation where nothing was ever applied is left alone instead.
+	// See TestRestoreCurrent_DoesNotEnforceAnInstallationNobodyConfigured.
+	configureTestFirewall(t, fw)
 
 	err := fw.RestoreCurrent(RestoreReasonBoot)
 	if err == nil {
@@ -679,6 +683,7 @@ func TestRestoreCurrent_RecordsTheBridgesItBakedIn(t *testing.T) {
 
 	cfg := newTestConfig(t)
 	f := newTestFirewall(t, cfg)
+	configureTestFirewall(t, f)
 
 	if got := f.getBootBridges(); len(got) != 0 {
 		t.Fatalf("a fresh firewall already records %v", got)
@@ -694,5 +699,90 @@ func TestRestoreCurrent_RecordsTheBridgesItBakedIn(t *testing.T) {
 			"reconciler cannot tell a host whose bridges were already there from one "+
 			"whose bridges have not appeared yet, and restores a second time on every "+
 			"container host", got)
+	}
+}
+
+// A host that has never been configured is left exactly as easywall found it.
+//
+// The incident: a VPS was cut off from its owner immediately after
+// `docker compose up -d`. RulesStore initialises rules.json with emptyState(),
+// Daemon.Start restores it unconditionally, and an empty rule set at policy drop
+// closes every port — SSH, and the web interface whose first-run wizard is the
+// only thing that would have opened SSH. `dpkg -i` reaches the same place; the
+// documented first step is https://localhost:12227, and loopback is accepted,
+// which is why it was never seen locally.
+//
+// The evidence that nothing was written: the test firewall has a nil netlink
+// connection, so any restore that reaches nftables fails at Reset and records
+// boot_enforce_failed — as TestRestoreCurrent_AttemptsAndRecordsFailure above
+// asserts it does on a configured host. Getting boot_not_configured instead, and
+// a nil error, is proof this one turned back before the kernel.
+func TestRestoreCurrent_DoesNotEnforceAnInstallationNobodyConfigured(t *testing.T) {
+	cfg := newTestConfig(t)
+	fw := newTestFirewall(t, cfg)
+
+	if err := fw.RestoreCurrent(RestoreReasonBoot); err != nil {
+		t.Errorf("restoring an unconfigured installation must succeed by doing nothing, got %v", err)
+	}
+
+	got := auditActions(t, cfg)
+	if len(got) != 1 || got[0] != "boot_not_configured" {
+		t.Fatalf("audit says %v, want exactly one boot_not_configured\n"+
+			"  boot_enforce_failed here means the restore reached nftables and would "+
+			"have installed a drop-all table on a machine nobody has configured", got)
+	}
+}
+
+// An operator who deliberately applied an empty rule set keeps it across a
+// reboot. That choice was made through an acceptance window that let them undo
+// it, which is exactly what a fresh install has never had.
+//
+// Without this the guard above would be "empty means never configured", and a
+// host somebody deliberately left wide open — or one upgrading from a release
+// before the guard existed, where Current may legitimately be empty — would
+// quietly stop being restored at boot.
+func TestRestoreCurrent_EnforcesAnEmptySetSomebodyApplied(t *testing.T) {
+	cfg := newTestConfig(t)
+	fw := newTestFirewall(t, cfg)
+
+	// The marker an accepted apply leaves behind, and nothing else: Current
+	// stays empty, so the marker is the only thing saying this host is configured.
+	fw.setLastApply(time.Now())
+
+	err := fw.RestoreCurrent(RestoreReasonBoot)
+	if err == nil {
+		t.Fatal("the restore must reach nftables and fail there on the nil connection")
+	}
+
+	got := auditActions(t, cfg)
+	if len(got) != 1 || got[0] != "boot_enforce_failed" {
+		t.Errorf("audit says %v, want exactly one boot_enforce_failed\n"+
+			"  boot_not_configured here means a deliberately-applied empty rule set "+
+			"stopped being enforced across a reboot", got)
+	}
+}
+
+// The two signals are independent: a non-empty Current with no marker is a
+// configured host too. That is the shape an installation has between the
+// first-run apply and the marker being written, and the shape of any host whose
+// marker file was lost.
+func TestEverConfigured_TakesEitherSignal(t *testing.T) {
+	cfg := newTestConfig(t)
+	fw := newTestFirewall(t, cfg)
+
+	var state shared.RulesState
+	if fw.everConfigured(state) {
+		t.Error("empty Current and no last-apply marker is an unconfigured installation")
+	}
+
+	state.Current.TCP = []shared.PortRule{{Port: "22"}}
+	if !fw.everConfigured(state) {
+		t.Error("a rule in Current means somebody configured this host")
+	}
+
+	state.Current = shared.Rules{}
+	fw.setLastApply(time.Now())
+	if !fw.everConfigured(state) {
+		t.Error("a last-apply marker means somebody applied something, empty or not")
 	}
 }

--- a/internal/shared/models.go
+++ b/internal/shared/models.go
@@ -46,6 +46,27 @@ type Rules struct {
 	Custom     []string         `json:"custom"`     // raw nftables rule strings
 }
 
+// IsEmpty reports whether this rule set says nothing at all.
+//
+// The distinction it exists for: an empty rule set is not a firewall policy, it
+// is the absence of one. RulesStore initialises a host that has never been
+// configured with exactly this value, and enforcing it means an input chain at
+// policy drop with nothing open — SSH closed, and the web interface that would
+// have opened it closed with it. See Firewall.everConfigured.
+//
+// Every field of Rules is counted, and TestRulesIsEmptyCountsEveryField holds it
+// to that by reflection: a seventh rule set added here and forgotten below would
+// make a configured host look unconfigured, which is the one direction that
+// silently stops a firewall.
+func (r Rules) IsEmpty() bool {
+	return len(r.TCP) == 0 &&
+		len(r.UDP) == 0 &&
+		len(r.Blacklist) == 0 &&
+		len(r.Whitelist) == 0 &&
+		len(r.Forwarding) == 0 &&
+		len(r.Custom) == 0
+}
+
 // RulesState holds the three-state rules system preventing lockouts.
 // current = applied to kernel, staged = pending user apply, backup = rollback target.
 type RulesState struct {

--- a/internal/shared/rules_isempty_test.go
+++ b/internal/shared/rules_isempty_test.go
@@ -1,0 +1,44 @@
+package shared
+
+import (
+	"reflect"
+	"testing"
+)
+
+// IsEmpty decides whether a host counts as configured, and a field it forgets
+// reads as "nothing here" — which is the direction that stops a firewall
+// enforcing rules somebody wrote. Same shape as TestDiffRulesReachesEveryRuleSet
+// and for the same reason: the list is derived from the struct, not typed out
+// beside it.
+//
+// Verify by mutation: drop any clause from Rules.IsEmpty and the matching
+// subtest goes red.
+func TestRulesIsEmptyCountsEveryField(t *testing.T) {
+	if (Rules{}).IsEmpty() != true {
+		t.Fatal("a zero Rules must be empty; nothing below means anything otherwise")
+	}
+
+	rt := reflect.TypeOf(Rules{})
+	for i := range rt.NumField() {
+		field := rt.Field(i)
+		t.Run(field.Name, func(t *testing.T) {
+			if field.Type.Kind() != reflect.Slice {
+				t.Fatalf("%s is a %s, not a slice — IsEmpty counts lengths and cannot "+
+					"see this field at all", field.Name, field.Type.Kind())
+			}
+
+			// One element of whatever this field holds, so the check is the
+			// struct's own shape rather than a fixture that has to be updated.
+			var r Rules
+			v := reflect.ValueOf(&r).Elem().Field(i)
+			v.Set(reflect.MakeSlice(field.Type, 1, 1))
+
+			if r.IsEmpty() {
+				t.Errorf("Rules with one %s entry reports IsEmpty() = true\n"+
+					"  a host whose only configuration is this rule set would be treated as "+
+					"never configured, and its stored rules would stop being enforced at boot",
+					field.Name)
+			}
+		})
+	}
+}

--- a/internal/shared/version.go
+++ b/internal/shared/version.go
@@ -26,7 +26,7 @@ import (
 // stylesheet URL never changed across an upgrade even though it is versioned
 // precisely so that it does. `easywall-core --version` prints this, so a build
 // can be checked rather than assumed.
-var CurrentVersion = "2.15.0"
+var CurrentVersion = "2.15.1"
 
 const (
 	// cacheMaxAge is how long a successful check is trusted.

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -787,6 +787,7 @@ var auditActionLabels = map[string]string{
 	// unknown identifier — but in whatever the raw snake_case says, in no
 	// language a translator chose.
 	"boot_enforced":          "audit_boot_enforced",
+	"boot_not_configured":    "audit_boot_not_configured",
 	"boot_enforce_failed":    "audit_boot_enforce_failed",
 	"panic_engaged":          "audit_panic_engaged",
 	"panic_resumed":          "audit_panic_resumed",
@@ -836,6 +837,16 @@ var auditActionTones = map[string]string{
 	// operator watching a page to notice.
 	"boot_enforced":       "ok",
 	"boot_enforce_failed": "crit",
+
+	// boot_not_configured: the daemon started on a host where nothing has ever
+	// been applied, and left it alone rather than enforcing the empty rule set
+	// RulesStore initialises. Amber, not neutral and not red — the machine is
+	// not filtering, which is a firewall state and not a staging step, but it is
+	// waiting on the operator rather than reporting a fault. Red here would put
+	// a fresh install's first audit line at the same weight as
+	// boot_enforce_failed, which is a machine that was supposed to be filtering
+	// and is not.
+	"boot_not_configured": "warn",
 
 	// panic_engaged / panic_resumed: deliberate does not make it neutral. The
 	// rule is what the firewall is doing, not whether a human meant it —

--- a/locales/de.json
+++ b/locales/de.json
@@ -237,6 +237,7 @@
   {"id": "audit_settings_saved", "translation": "Netzwerkeinstellungen gespeichert"},
   {"id": "audit_system_saved", "translation": "Systemeinstellungen gespeichert"},
   {"id": "audit_boot_enforced", "translation": "Regeln beim Start wiederhergestellt"},
+  {"id": "audit_boot_not_configured", "translation": "Filtert nicht — noch nichts konfiguriert"},
   {"id": "audit_boot_enforce_failed", "translation": "Regeln konnten beim Start nicht wiederhergestellt werden"},
   {"id": "audit_panic_engaged", "translation": "Notfallmodus aktiviert"},
   {"id": "audit_panic_resumed", "translation": "Notfallmodus beendet"},

--- a/locales/en.json
+++ b/locales/en.json
@@ -237,6 +237,7 @@
   {"id": "audit_settings_saved", "translation": "Settings saved"},
   {"id": "audit_system_saved", "translation": "System settings saved"},
   {"id": "audit_boot_enforced", "translation": "Rules restored at startup"},
+  {"id": "audit_boot_not_configured", "translation": "Not filtering — nothing configured yet"},
   {"id": "audit_boot_enforce_failed", "translation": "Rules could not be restored at startup"},
   {"id": "audit_panic_engaged", "translation": "Panic mode engaged"},
   {"id": "audit_panic_resumed", "translation": "Panic mode ended"},

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -226,6 +226,7 @@
   {"id": "audit_settings_saved", "translation": "Paramètres enregistrés"},
   {"id": "audit_system_saved", "translation": "Paramètres système enregistrés"},
   {"id": "audit_boot_enforced", "translation": "Règles restaurées au démarrage"},
+  {"id": "audit_boot_not_configured", "translation": "Aucun filtrage — rien n'est encore configuré"},
   {"id": "audit_boot_enforce_failed", "translation": "Les règles n'ont pas pu être restaurées au démarrage"},
   {"id": "audit_panic_engaged", "translation": "Mode panique activé"},
   {"id": "audit_panic_resumed", "translation": "Mode panique terminé"},


### PR DESCRIPTION
Reported in Discord: a VPS unreachable immediately after `docker compose up -d`, and still cutting SSH on every later `docker` start. The pasted ruleset carried the evidence for both causes.

## 1 — The conntrack state masks were byte-reversed

The kernel writes `ct state` into a register as a native `u32`. All three masks in `internal/core/nftables.go` were written as `[]byte{0x00, 0x00, 0x00, 0x06}` instead of `{0x06, 0x00, 0x00, 0x00}`, so the kernel rendered them back as `ct state 0x2000000,0x4000000` — bits no conntrack state sets.

| Rule | Effect |
|---|---|
| `ct state established,related accept` | **matched nothing** — the entire stateful half of the input chain |
| `ct state invalid drop` | module reported itself on, enforced nothing |
| `ct state new jump sshbrute` | meter never fired |

The first is the lockout: without it a reply packet has no rule to match, so **an installation with a live table had no working outbound connectivity at all** — no DNS, no `apt update`, no version check — and applying the table dropped any SSH session already open, because the only rules still matching were the stateless `dport N accept` ones.

Measured in a veth pair against an HTTP server, with a no-ruleset control:

| Ruleset | rendered | counter | HTTP |
|---|---|---|---|
| none (control) | — | — | 200 |
| before | `ct state 0x2000000,0x4000000` | **0 packets** | FAIL |
| after | `ct state established,related` | 6 packets | 200 |

`binaryutil.NativeEndian` is what this same file already uses for a register-width constant; these three were the outliers.

### Why it survived five releases

`nftables_semantics_test.go` asserted the broken rendering — `dport 2222 ct state 0x8000000 jump sshbrute` — under a comment explaining that "nft prints the mask rather than the name". Both halves were wrong: `nft` names every state it recognises, including for a bitwise-and plus a not-equal-zero test, because that is how it compiles `ct state new` itself. It printed hex precisely because the mask was reversed. The assertion was written from observed output rather than from intent.

## 2 — A fresh install enforced an empty rule set

`RulesStore` initialises `rules.json` with `emptyState()` and `Daemon.Start` restored it unconditionally, so the input chain came up at `policy drop` with no port open — SSH closed, and the web interface whose first-run wizard is the only thing that opens SSH closed with it. `docker compose up -d` and `dpkg -i` both start the core before the operator can open a single port.

`RestoreCurrent`'s own contract rests on `Current` being "a rule set that has already survived an acceptance window", which is not true of one nobody has ever applied. `Firewall.everConfigured` makes it hold: a non-empty `Current` **or** a last-apply marker counts as configured, so a deliberately-applied empty set and an upgrading installation both keep filtering. Otherwise the machine is left exactly as easywall found it, and filtering starts at the first deliberate apply — the one with the acceptance window.

New audit action `boot_not_configured`, amber, in all three locales and the audit-log page.

## Proof

Every guard verified by mutation, not by reading — reversing `ctStateMask` reproduces the reporter's line verbatim:

```
--- FAIL: TestIntegration_NoCtStateRendersAsARawMask
    the table holds 3 ct state match(es) the kernel cannot name:
    [ct state 0x2000000 ct state 0x1000000 ct state 0x8000000]
        ct state 0x2000000,0x4000000 accept
        ct state 0x1000000 drop
        tcp dport 22 ct state 0x8000000 jump sshbrute
```

- `TestIntegration_NoCtStateRendersAsARawMask` fails on **any** hex-rendered ct state — the class, not the three instances
- `TestCtStateMaskIsTheByteOrderTheKernelCompares` takes its expected bytes from `nft --debug=netlink`, not from the implementation
- `TestRulesIsEmptyCountsEveryField` derives its field list by reflection
- Both halves of `everConfigured` independently mutation-checked

Unit suite green, full integration suite green against a real kernel (25.9 s), `golangci-lint` 0 issues, `check:prose`/`check:docs`/`check:changelog` green.

## Not fixed here

Two findings proven against `main` before this branch, recorded in `docs-tech/carried-forward.md`: three landing-page classes `docs.css` does not define, and `docker.md` telling a remote operator to open `https://localhost:12227` — the instruction that is why both defects went unseen locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)