### PR TITLE
check:ui's language switch waits for the response, not the request

### DIFF
--- a/docs-tech/carried-forward.md
+++ b/docs-tech/carried-forward.md
@@ -16,6 +16,12 @@ the sentence.
 Not published — this directory sits outside `docs/`, which is the entire Jekyll
 source. See `TestTheTechnicalDocsAreNotPublished`.
 
+# From the check:ui race fix
+
+| | |
+|---|---|
+| **`checkPortsCatalogue` is not idempotent against a demo server that has already run it** | Picking Pi-hole a second time adds its rows to a set that already holds them, and the check fails with *"picking Pi-hole added 4 TCP rows, expected 2"*. Invisible in CI, which starts a fresh `easywall-web` for every run; it bites only a maintainer whose `scripts/demo-server.sh` has been up across two `npm run check:ui` invocations — where it reads as a real regression and costs a bisect. Reproduced on unmodified `main`, so it predates this branch. The fix is either a check that tolerates the rows already being there or a demo reset the script performs itself, and that is a decision about what `check:ui` may do to a maintainer's running session |
+
 # From 2.15.1
 
 Found while analysing the Discord lockout report, proven against `main` before

--- a/scripts/ui-check.mjs
+++ b/scripts/ui-check.mjs
@@ -816,20 +816,27 @@ async function checkSignOutEndsTheSession(page) {
  */
 /**
  * Picks a language from the select and waits for the POST it is supposed to
- * trigger. Returns whether that POST actually happened.
+ * trigger to be *answered*. Returns whether that happened.
  *
- * The wait is armed *before* the option is picked, and it waits for the request
- * rather than for a load state. `selectOption` then `waitForLoadState` looks
- * equivalent and is not: the page is already loaded when the second call runs,
- * so if the change handler has not yet started its navigation, the wait
- * resolves against the load that already happened and the cookie is read
- * before the POST has been made. That passes on a fast machine and fails on a
- * CI runner, which is exactly what it did — a green check locally and one red
- * job with "cookie is unset".
+ * The wait is armed before the option is picked, and it waits for the response
+ * rather than for the request or for a load state. Each of the two weaker waits
+ * has its own failure:
+ *
+ *   - `waitForLoadState` alone resolves against the document that is already
+ *     loaded, because the page has not started navigating yet when it is called.
+ *   - `waitForRequest` resolves when the browser has *sent* the POST, which is
+ *     still one round trip before Set-Cookie exists. The waitForLoadState after
+ *     it then returns against that same already-loaded document, and
+ *     ctx.cookies() is read before the server has answered.
+ *
+ * The second is what shipped, and it did exactly what a race does: green on a
+ * fast machine, and one red CI job reporting "the POST went through but the
+ * cookie is unset". waitForResponse is the wait that means the cookie exists.
  */
 async function switchTo(page, code) {
   const posted = page
-    .waitForRequest(r => r.url().endsWith('/language') && r.method() === 'POST', { timeout: 5000 })
+    .waitForResponse(r => r.url().endsWith('/language') && r.request().method() === 'POST',
+      { timeout: 5000 })
     .then(() => true, () => false);
   await page.locator('#lang-select').selectOption({ value: code });
   const ok = await posted;
@@ -886,8 +893,9 @@ async function checkLanguageSwitch(ctx) {
       'an operator who cannot read the interface would have no way to change it');
   } else {
     await noJsPage.locator('#lang-select').selectOption({ value: 'de' });
-    // click() auto-waits for the navigation a submit button starts, so this one
-    // was never racy the way the change handler above was.
+    // click() auto-waits for the navigation a submit button starts, so unlike
+    // the change handler above this path never needed an explicit wait of its
+    // own — the difference is the control, not the care taken over it.
     await noJsSubmit.click();
     await noJsPage.waitForLoadState('load');
     const lang = (await noJsCtx.cookies()).find(c => c.name === 'easywall_lang');


### PR DESCRIPTION
2.16's spec opens by requiring `main` to be green before the branch is cut, and names this as the thing that has to land first. A release that starts on a red base cannot prove anything is pre-existing — the exact mistake 2.15 made.

## The race

`switchTo` armed a `waitForRequest`. That resolves when the browser has **sent** the POST, which is still one round trip before `Set-Cookie` exists. The `waitForLoadState('load')` after it then returned against the document that was already loaded — the navigation had not started yet — and `ctx.cookies()` was read before the server had answered.

Green on a fast machine, and one red CI job reporting `the POST went through but the cookie is unset`.

`waitForResponse` is the wait that means the cookie exists. It is already the idiom this file uses twice, at `ui-check.mjs:218` for the login POST and `:631` for the system POST; the language switch was the outlier.

The stale comment fifty lines below is corrected with it. It read *"this one was never racy the way the change handler above was"*, which now describes two non-racy paths. The difference is the control, not the care taken over it: `click()` auto-waits for the navigation a submit button starts.

## Verified

Full `npm run check:ui` against a freshly started demo server:

```
ok   the select submits itself on change with JavaScript running
ok   the submit button works with JavaScript disabled
ok   13 pages clean at dark 1600px … light 390px   (10 passes)
…
UI checks passed
```

## One finding, recorded not fixed

The first run failed `ports catalogue` — *"picking Pi-hole added 4 TCP rows, expected 2"*. Reproduced on unmodified `main` by stashing this change, so it predates the branch. The cause is a demo server that had been up across two `check:ui` invocations: picking Pi-hole a second time adds its rows to a set that already holds them. CI never sees it, because it starts a fresh `easywall-web` every run — so it only ever bites a maintainer, where it reads as a regression and costs a bisect.

Whether the fix belongs in the check or in `demo-server.sh` is a decision about what `check:ui` may do to a maintainer's running session, so it is in `docs-tech/carried-forward.md` rather than in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)