### PR TITLE
docs-tech: the 2.16 spec and its implementation plan

### DIFF
--- a/docs-tech/plans/2026-09-07-2.16-the-interface-looks-like-a-firewall-implementation.md
+++ b/docs-tech/plans/2026-09-07-2.16-the-interface-looks-like-a-firewall-implementation.md
@@ -109,8 +109,8 @@ Read these before Task 1. Each one changes what a task does.
 4. **`--color-accent-hover` has no replacement for the job it did.** It was
    `.btn-primary:hover`. The token it maps to is `focus-ring`, which is the wrong
    role. Task 3 uses `--color-ink-muted` for that hover and Task 9 documents it as
-   `button-primary-hover`; measured, `action-ink` on `ink-muted` is 8.1:1 dark and
-   5.8:1 light.
+   `button-primary-hover`; measured, `action-ink` on `ink-muted` is 8.41:1 dark and
+   6.15:1 light.
 5. **`.chip-accent` is live markup.** `ports.html:153` renders it for the *private
    source* suggestion. It becomes `.chip-select`. `TestTemplateClassesExistInStylesheet`
    fails until both the template and the rebuilt stylesheet agree.
@@ -137,6 +137,25 @@ Read these before Task 1. Each one changes what a task does.
     compares the two. It is the guard working, not a guard to silence.
 
 ---
+
+## The spec's measurements, re-derived
+
+Every contrast figure the spec states was recomputed from the token values
+before this plan was written, so a task that quotes one is quoting a checked
+number rather than copying it forward:
+
+| pair | spec | recomputed |
+|---|---|---|
+| `accent-wash` 0.13 composited over `surface`, dark | 1.31:1 | 1.31:1 |
+| `accent` border over `surface`, dark | 11.4:1 | 11.40:1 |
+| `focus-ring` / `surface`, dark | 16.72:1 | 16.72:1 |
+| `focus-ring` / `surface`, light | 18.88:1 | 18.88:1 |
+| `accent` fill / `surface`, light | 4.73:1 | 4.73:1 |
+| `select-fill` / `surface`, both themes | 1.08:1 | 1.08:1 |
+
+The two numbers this plan adds rather than quotes — `action-ink` on `ink-muted`,
+which is the primary button's new hover — measure **8.41:1** dark and **6.15:1**
+light.
 
 ## Dependency graph
 
@@ -1925,7 +1944,7 @@ advance, 11.4 em, roughly 358 px available at a 390 px viewport, 31.4 px.
 - [ ] **Step 5: Components**
 
 - *Buttons*: the primary action is `action-fill` with `action-ink`; hover is
-  `ink-muted` (8.1:1 dark, 5.8:1 light for the ink on it).
+  `ink-muted` (8.41:1 dark, 6.15:1 light for the ink on it).
 - *Chips and tags*: `chip-accent` becomes `chip-select`; it marks a qualifier the
   operator chose.
 - *Tables*: add the new rule —

--- a/docs-tech/plans/2026-09-07-2.16-the-interface-looks-like-a-firewall-implementation.md
+++ b/docs-tech/plans/2026-09-07-2.16-the-interface-looks-like-a-firewall-implementation.md
@@ -132,17 +132,31 @@ Read these before Task 1. Each one changes what a task does.
 9. **`.docs-hero-accent` is a class name, not a token.** `docs/index.md:22` uses
    it. It is renamed in Task 8; a guard that greps for the string `accent` would
    otherwise fail on markup rather than on colour.
-10. **Three controls have no focus indicator at all, and the spec did not measure
-    them.** Task 2's check was prototyped against the running demo before this plan
-    was finished. It reports **44 of 46** focusable elements below 3:1 on five pages
-    in dark mode — and the worst are not the 1.31:1 the spec names. `.nav-links li
-    a`, `.nav-footer .logout-btn` and `.tab` measure **1.02–1.03:1**, because
-    `web/src/app.css` has no `:focus-visible` rule for any of them: fourteen
-    selectors carry one and those three do not. That is WCAG 2.4.7 *Focus Visible*
-    at **Level A**, a stronger failure than the 1.4.11 the spec is written around —
-    tabbing through the sidebar today moves through nothing visible at all. Task 3
-    therefore **adds** three rules rather than remapping them; they are in its
-    mapping table, marked *(new)*.
+10. **The focus defect is a class of seven controls, not the two the spec names —
+    and measuring it correctly takes three tricks.** Task 2's check was built and
+    run against the demo before this plan was finished, which is the point of
+    writing the guard first. Confirmed rendered, dark theme, 13 pages:
+
+    | control | composited | the spec |
+    |---|---|---|
+    | `.toggle`, `.checkbox` | 1.31 / 1.34:1 | named, *"to be confirmed rendered"* — **confirmed** |
+    | `.theme-toggle` (all 13 pages) | 1.31:1 | not named |
+    | `.link` (11 pages) | 1.31:1 | not named |
+    | `.editor textarea` ×3, `.f-ssh` | 1.31:1 | not named |
+    | `.input`, `.btn`, `.lang-select`, `.stat-tile`, `.chip` | **pass** | *"the border is what actually carries focus"* — **confirmed** |
+
+    66 failures in dark and the same again in light, and the whole failing set is
+    one shape: a ring and **no border change**. Every control whose border moves
+    on focus already clears 3:1, exactly as §1 says. Task 3 does not need to
+    invent anything — it needs the ring to stop being a 13% wash.
+
+    A separate, quieter finding: 28 controls — every sidebar nav link and every
+    `.logout-btn` — carry **no author focus rule at all** and fall back to
+    Chrome's own `outline: auto`. That ring is visible and accessible, so it is
+    not a WCAG failure and the check reports it as a note rather than a failure.
+    It is still a design-system inconsistency: `DESIGN.md` says focus is a border
+    change plus an outline, and these opt out of both without saying so.
+
 11. **`grid-row: span 4` must become `span 3`.** Removing `.stat-tile-cta` takes a
     tile from four children to three, and `TestStatTileSpanMatchesItsChildren`
     compares the two. It is the guard working, not a guard to silence.
@@ -476,24 +490,39 @@ In `runChecks`, after the language switch and before the width loop:
 scripts/demo-server.sh &
 npm run check:ui
 ```
-Expected: **FAIL**. Prototyped against the running demo before this plan was
-written, five pages, dark theme, and the numbers to expect are:
+Expected: **FAIL, 66 times in dark and again in light.** Measured before this
+plan was finished:
 
 ```
-worst 12 focus indicators, dark, composited:
-  1.02:1  /dashboard .A            ← sidebar nav link: no :focus-visible rule at all
-  1.02:1  /dashboard .logout-btn   ← same
-  1.03:1  /ports .tab              ← same
-  1.27:1  /dashboard .btn
-  ...
-below 3:1 : 44 of 46
+FAIL focus contrast [dark]
+     /options .toggle          — composites to 1.31:1
+     /options .checkbox        — composites to 1.34:1
+     /dashboard .theme-toggle  — 1.31:1     (all 13 pages)
+     /ports .link              — 1.31:1     (11 pages)
+     /blacklist .Blocked addresses — 1.31:1 (the three editor textareas)
+note 28 control(s) fall back to the browser's own focus ring in dark:
+     /dashboard .A, /dashboard .logout-btn, …
 ```
+
+`.input`, `.btn`, `.lang-select`, `.stat-tile` and `.chip` must **pass** — their
+border moves on focus and reaches 11.4:1. A check that fails those too is
+measuring wrong, and there are three specific ways to measure this wrong. All
+three were hit while building it:
+
+| trap | what it looks like | why |
+|---|---|---|
+| Focusing with `el.focus()` | every control reports its *resting* outline, and `.btn` / `.input` come back `matches(':focus-visible') === false` | `:focus-visible` is a heuristic about **how** focus arrived, and programmatic focus does not satisfy it for a button. The spec says *"Tab through"* and means it — drive real `keyboard.press('Tab')`. |
+| Trusting `outlineColor` when `outlineStyle` is `auto` | the sidebar links report `rgb(16,16,16)` → 1.02:1, and read as a catastrophic Level A failure | `outline: auto` is the browser's own ring. Chrome paints a high-contrast double ring and reports a colour that is not what it paints. Treat `auto` as a pass and report it separately. |
+| Reading `getComputedStyle` in the same task as the key press | every border-carried focus reports at its outline value alone — `.input` at 1.31:1 instead of 11.4:1 | the style recalculation has not landed, and `.input` carries `transition: border-color 120ms` on top of that. Run the context with `reducedMotion: 'reduce'` — which `app.css` already answers by zeroing every transition — and wait two `requestAnimationFrame`s inside the evaluate. |
+
+One more, which is not a trap but a design choice: the resting border cannot be
+read during the walk, because the element is focused at that moment and its
+computed border is already the focused one. It is stamped onto every focusable
+element as a `data-` attribute before the walk. Reading it off a clone appended
+beside the element also works, and mutates the DOM in the middle of a tab order.
 
 If it passes, the check is not measuring what the spec measured — do not proceed
-to Task 3 until it is red. If it reports only the 1.31:1 controls and not the
-1.02:1 ones, the element list is too narrow: three controls answer focus with
-nothing, and a check that only inspects outlines it already expects will not
-see them.
+to Task 3 until it is red.
 
 - [ ] **Step 4: Commit the red guard**
 
@@ -688,15 +717,17 @@ mapping, site by site:
 | `.module:has(.toggle:checked)` | `inset 2px 0 0 var(--color-accent)` | `var(--color-select-edge)` |
 | `.module:focus-within` | `border-color: var(--color-accent)` | `var(--color-focus-ring)` |
 | `.demo-chip-dot` | `background: var(--color-accent)` | `var(--color-ink-subtle)` — a demo marker is not a state |
-| `.nav-links li a:focus-visible` | **(new)** — no rule exists | `outline: 2px solid var(--color-focus-ring); outline-offset: -2px` |
-| `.nav-footer .logout-btn:focus-visible` | **(new)** — no rule exists | `outline: 2px solid var(--color-focus-ring); outline-offset: -2px` |
-| `.tab:focus-visible` | **(new)** — no rule exists | `outline: 2px solid var(--color-focus-ring); outline-offset: -2px` |
+| `.nav-links li a:focus-visible` | **(new)** — no author rule exists | `outline: 2px solid var(--color-focus-ring); outline-offset: -2px` |
+| `.nav-footer .logout-btn:focus-visible` | **(new)** — no author rule exists | `outline: 2px solid var(--color-focus-ring); outline-offset: -2px` |
+| `.tab:focus-visible` | **(new)** — no author rule exists | `outline: 2px solid var(--color-focus-ring); outline-offset: -2px` |
 
-The three marked *(new)* are not part of the token swap and would not be found
-by following it: they have no accent to replace, because they have no focus
-treatment at all. Measured at 1.02–1.03:1 — see finding 10. `outline-offset` is
-negative on all three so the ring sits inside the nav item's own rounded box
-rather than colliding with its neighbour.
+The three marked *(new)* are not part of the token swap and following it would
+never find them: they have no accent to replace. They are not broken — they fall
+back to Chrome's own focus ring, which is visible, and Task 2's check reports
+them as a note rather than a failure. They are **inconsistent**: `DESIGN.md` says
+focus is a border change plus an outline, and 28 controls opt out of both
+without saying so. `outline-offset` is negative so the ring sits inside the nav
+item's own rounded box rather than colliding with its neighbour.
 
 Two prose comments name the accent and must be rewritten rather than left
 lying: the block above `.page-header` (~line 620) and the one above `.link`.
@@ -1556,10 +1587,23 @@ behaviour is exactly what varies with width.
 scripts/demo-server.sh &
 npm run check:ui
 ```
-Expected: **FAIL**, naming `.table-wrap` at roughly 10 px over, on `/ports`,
-`/forwarding` and `/log`, at the widths where the container query has switched
-to cards. If it is green, the check is not measuring what
-`carried-forward.md` measured — do not proceed to 7b.
+Expected: **FAIL, 24 times.** Measured before this plan was finished:
+
+```
+FAIL container overflow [dark 900px]
+     /ports   .table-wrap is 614px and holds 624px, 10px over
+     /ports?type=udp, /forwarding, /log — the same
+```
+
+Four pages × three widths × two themes, and **clean at 1600 and 1440** — exactly
+the widths where the container query has not switched to cards. Ten pixels at
+every container width (360, 614, 914), not a proportion of it: a fixed overhang,
+which agrees with what `carried-forward.md` measured with six, five and four
+columns and with `white-space: nowrap` removed. **10, not 20** — so one side
+overhangs, not both, which is what step 1 of 7b asks you to confirm.
+
+If it is green, the check is not measuring what `carried-forward.md` measured —
+do not proceed to 7b.
 
 - [ ] **Step 5: Commit the red check on its own**
 

--- a/docs-tech/plans/2026-09-07-2.16-the-interface-looks-like-a-firewall-implementation.md
+++ b/docs-tech/plans/2026-09-07-2.16-the-interface-looks-like-a-firewall-implementation.md
@@ -132,7 +132,18 @@ Read these before Task 1. Each one changes what a task does.
 9. **`.docs-hero-accent` is a class name, not a token.** `docs/index.md:22` uses
    it. It is renamed in Task 8; a guard that greps for the string `accent` would
    otherwise fail on markup rather than on colour.
-10. **`grid-row: span 4` must become `span 3`.** Removing `.stat-tile-cta` takes a
+10. **Three controls have no focus indicator at all, and the spec did not measure
+    them.** Task 2's check was prototyped against the running demo before this plan
+    was finished. It reports **44 of 46** focusable elements below 3:1 on five pages
+    in dark mode — and the worst are not the 1.31:1 the spec names. `.nav-links li
+    a`, `.nav-footer .logout-btn` and `.tab` measure **1.02–1.03:1**, because
+    `web/src/app.css` has no `:focus-visible` rule for any of them: fourteen
+    selectors carry one and those three do not. That is WCAG 2.4.7 *Focus Visible*
+    at **Level A**, a stronger failure than the 1.4.11 the spec is written around —
+    tabbing through the sidebar today moves through nothing visible at all. Task 3
+    therefore **adds** three rules rather than remapping them; they are in its
+    mapping table, marked *(new)*.
+11. **`grid-row: span 4` must become `span 3`.** Removing `.stat-tile-cta` takes a
     tile from four children to three, and `TestStatTileSpanMatchesItsChildren`
     compares the two. It is the guard working, not a guard to silence.
 
@@ -465,9 +476,24 @@ In `runChecks`, after the language switch and before the width loop:
 scripts/demo-server.sh &
 npm run check:ui
 ```
-Expected: **FAIL**, naming `.input`, `.toggle` and `.checkbox` at roughly
-`1.31:1` in dark. If it passes, the check is not measuring what the spec
-measured — do not proceed to Task 3 until it is red.
+Expected: **FAIL**. Prototyped against the running demo before this plan was
+written, five pages, dark theme, and the numbers to expect are:
+
+```
+worst 12 focus indicators, dark, composited:
+  1.02:1  /dashboard .A            ← sidebar nav link: no :focus-visible rule at all
+  1.02:1  /dashboard .logout-btn   ← same
+  1.03:1  /ports .tab              ← same
+  1.27:1  /dashboard .btn
+  ...
+below 3:1 : 44 of 46
+```
+
+If it passes, the check is not measuring what the spec measured — do not proceed
+to Task 3 until it is red. If it reports only the 1.31:1 controls and not the
+1.02:1 ones, the element list is too narrow: three controls answer focus with
+nothing, and a check that only inspects outlines it already expects will not
+see them.
 
 - [ ] **Step 4: Commit the red guard**
 
@@ -662,6 +688,15 @@ mapping, site by site:
 | `.module:has(.toggle:checked)` | `inset 2px 0 0 var(--color-accent)` | `var(--color-select-edge)` |
 | `.module:focus-within` | `border-color: var(--color-accent)` | `var(--color-focus-ring)` |
 | `.demo-chip-dot` | `background: var(--color-accent)` | `var(--color-ink-subtle)` — a demo marker is not a state |
+| `.nav-links li a:focus-visible` | **(new)** — no rule exists | `outline: 2px solid var(--color-focus-ring); outline-offset: -2px` |
+| `.nav-footer .logout-btn:focus-visible` | **(new)** — no rule exists | `outline: 2px solid var(--color-focus-ring); outline-offset: -2px` |
+| `.tab:focus-visible` | **(new)** — no rule exists | `outline: 2px solid var(--color-focus-ring); outline-offset: -2px` |
+
+The three marked *(new)* are not part of the token swap and would not be found
+by following it: they have no accent to replace, because they have no focus
+treatment at all. Measured at 1.02–1.03:1 — see finding 10. `outline-offset` is
+negative on all three so the ring sits inside the nav item's own rounded box
+rather than colliding with its neighbour.
 
 Two prose comments name the accent and must be rewritten rather than left
 lying: the block above `.page-header` (~line 620) and the one above `.link`.

--- a/docs-tech/plans/2026-09-07-2.16-the-interface-looks-like-a-firewall-implementation.md
+++ b/docs-tech/plans/2026-09-07-2.16-the-interface-looks-like-a-firewall-implementation.md
@@ -1,0 +1,2134 @@
+# 2.16 — The interface looks like a firewall: implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the ice-blue accent from the application and the documentation
+site so that the only hue left anywhere is `state-ok` / `state-warn` /
+`state-crit`, and close the four structural defects that travel with it — the
+sidebar's missing divider and indent, six identical stat cards, the page title's
+missing typographic position, and the two table defects `carried-forward.md`
+holds from 2.15.
+
+**Architecture:** Five accent tokens in `web/src/app.css` are replaced one for
+one by five that name a role rather than a colour (`action-fill`, `action-ink`,
+`select-fill`, `select-edge`, `focus-ring`); `web/src/docs.css` carries a
+parallel replacement of its own four. Every consumer of the old tokens is
+rewritten in the same task as the declaration, because a removed custom property
+renders as `transparent` rather than as an error. Both stylesheets are Tailwind
+v4 entry points whose built output is committed, so every task that touches CSS
+rebuilds and greps the built file. Three guards — a grep over both stylesheets, a
+focus-contrast pass in `check:ui`, and a per-container overflow check — are what
+make the change permanent rather than a repaint.
+
+**Tech Stack:** Go 1.27, Tailwind CSS v4 (`@tailwindcss/cli`), Go
+`html/template`, Playwright (`playwright-core`) via `scripts/ui-check.mjs`,
+Jekyll for `docs/`.
+
+**Spec:** `docs-tech/specs/2026-09-07-2.16-the-interface-looks-like-a-firewall.md`
+
+---
+
+## Global Constraints
+
+Every task's requirements implicitly include this section. Values are copied
+verbatim from the spec.
+
+- **The base is `main` at 2.15.1 or later.** The spec's §0 named the flaky
+  `check:ui` language switch as the thing that had to land first. Since the spec
+  was written, 2.15.1 also shipped (PR #162) — the byte-reversed conntrack masks
+  and the fresh-install lockout. Branch from `main` **after both are merged**, and
+  record the exact base commit in the branch's first commit message. A release
+  that starts on a red base cannot prove anything is pre-existing.
+- **The five application tokens, one for one:**
+
+  | removed | added | Dark | Light | Role |
+  |---|---|---|---|---|
+  | `--color-accent` | `--color-action-fill` | `#f1f3f6` | `#0f1116` | fill of the one primary action on a page |
+  | `--color-accent-ink` | `--color-action-ink` | `#0a0b0f` | `#ffffff` | text and icons on it |
+  | `--accent-wash` | `--color-select-fill` | `#181b22` | `#f4f6f9` | surface of the active element |
+  | `--color-accent-on-wash` | `--color-select-edge` | `#f1f3f6` | `#0f1116` | the 2 px edge on it |
+  | `--color-accent-hover` | `--color-focus-ring` | `#f1f3f6` | `#0f1116` | 2 px, with `outline-offset: 2px` |
+
+- **The four documentation tokens**, named differently and four rather than five:
+  `--accent` → `--focus-ring`, `--accent-on` → `--link-ink`, `--accent-dim` →
+  `--select-fill`, `--accent-hover` → `--select-edge`.
+- **`state-ok`, `state-warn`, `state-crit` and their six `-on-wash` variants are
+  untouched.** After this release they are the only chromatic values in the
+  application.
+- **A background alone may never mark the active element.** `select-fill` is
+  1.08:1 against `surface` in both themes. `select-edge` carries "this one is
+  active"; `select-fill` only confirms it.
+- **Focus indicators must composite to ≥ 3:1** against their actual backdrop
+  (WCAG 2.1 SC 1.4.11 Non-text Contrast, AA). Not 2.4.13, which is AAA.
+- **Display type:** JetBrains Mono 300, tracking `-0.01em`, **30 px below 900 px
+  viewport width and 34 px at 900 px and above**. 30 is a ceiling reached by
+  measurement, not a preference.
+- **Both themes, three widths (1600 / 900 / 390) — verified by rendering, not by
+  reading CSS.** The Chrome extension, not Playwright. A broken extension call
+  means stop and ask.
+- **A generated file is rebuilt and diffed, never assumed.** `npm run build:css`
+  and `npm run build:docs-css` produce committed output; grep the built file for
+  the rule you think you added. Tailwind drops rules silently and the build stays
+  green. The **diagrams** are the exception: `build:diagrams` is not
+  byte-reproducible, so `npm run check:diagrams` is the staleness test there.
+- **A test is verified by breaking the code, not by reading it.** Every guard in
+  this plan carries an explicit mutation step. A guard that does not go red under
+  its mutation has not been written yet.
+- **`en` and `de` stay at exact parity.** `fr` may have gaps — a missing key
+  renders `en` and is counted by the coverage report. `TestLocaleFilesAreAtParity`
+  enforces the first; nothing enforces the second.
+- **A fix carries its documentation.** Both locales, the schema, the UI copy, or
+  the next audit finds the mismatch you created.
+- **Nothing may be deferred that this release causes.** `carried-forward.md` is
+  for what the work *found*, proven against the pre-branch base — `origin/main`
+  before the branch, never the branch head.
+
+## Findings from planning that the spec does not settle
+
+Read these before Task 1. Each one changes what a task does.
+
+1. **`dashboard_running` has two call sites, not one.** The spec removes the
+   `Running version …` line above the dashboard `h1`. The same key also builds the
+   *update available* banner three lines above it in `dashboard.html`. Removing the
+   key from the locales therefore requires the banner to be reworded, which Task 4
+   does. The spec's §3 and §9 both read as though there were one site.
+2. **The sidebar diagram and the sidebar prose disagree.** §5's ASCII draws a rule
+   above `RULES` **and** above `SYSTEM`; the prose one line below says *"The first
+   group carries no `border-top`: it follows Dashboard, not another group."* This
+   plan follows the **prose**, because it states a reason and cites the
+   documentation sidebar this whole section is copying, where
+   `.nav-group:first-of-type > .nav-group-label { border-top: none }` does exactly
+   that. Flag it in the pull request; it is one declaration to reverse if the
+   maintainer meant the diagram.
+3. **Four of the five new tokens are byte-identical to `ink`, and the fifth to
+   `surface-raised`.** `action-fill`, `select-edge` and `focus-ring` all carry
+   `#f1f3f6` / `#0f1116`; `select-fill` carries `#181b22` / `#f4f6f9`. That is not
+   a mistake to correct — the names are roles, and a role that shares a value
+   today may not tomorrow — but it must be **stated in `DESIGN.md`**, or the next
+   reader deletes four tokens as duplicates. Task 9 says it in the Colors section.
+4. **`--color-accent-hover` has no replacement for the job it did.** It was
+   `.btn-primary:hover`. The token it maps to is `focus-ring`, which is the wrong
+   role. Task 3 uses `--color-ink-muted` for that hover and Task 9 documents it as
+   `button-primary-hover`; measured, `action-ink` on `ink-muted` is 8.1:1 dark and
+   5.8:1 light.
+5. **`.chip-accent` is live markup.** `ports.html:153` renders it for the *private
+   source* suggestion. It becomes `.chip-select`. `TestTemplateClassesExistInStylesheet`
+   fails until both the template and the rebuilt stylesheet agree.
+6. **`.stat-tile-value-primary` is dead.** No template, no `app.js`, no docs page
+   names it. Delete it rather than remap it.
+7. **The brand mark is accent-coloured.** `.brand-icon` and `.auth-logo-mark` take
+   `background-color: var(--color-accent)` through a CSS mask. With no accent left
+   they take `--color-ink`. `DESIGN.md` § *Where the colour comes from* has a table
+   row saying `accent`; Task 9 changes it. The **baked** raster favicon and the
+   documentation copy stay `#0f7bab` — they are outside both stylesheets, already
+   differ from the app chrome in dark mode today, and re-rendering them is not in
+   this release's scope. Task 9 records that in `Known Gaps`.
+8. **`docs.css` carries nine literal chromatic values the token rename cannot
+   reach**: `rgba(34,211,238,…)` ×3 and `rgba(8,145,178,…)` ×3 (the retired Aurora
+   cyan and its light twin, on `.sidebar-version`, `.docs-hero-pill` and
+   `.docs-design-row-num`), and `rgba(45,212,191,0.08)` ×2 (teal, in the two hero
+   glows). A grep guard on token *names* passes straight over them. Task 8 removes
+   them and Task 8's guard names them explicitly.
+9. **`.docs-hero-accent` is a class name, not a token.** `docs/index.md:22` uses
+   it. It is renamed in Task 8; a guard that greps for the string `accent` would
+   otherwise fail on markup rather than on colour.
+10. **`grid-row: span 4` must become `span 3`.** Removing `.stat-tile-cta` takes a
+    tile from four children to three, and `TestStatTileSpanMatchesItsChildren`
+    compares the two. It is the guard working, not a guard to silence.
+
+---
+
+## Dependency graph
+
+Concurrent implementers each get their own worktree — reviewers mutate the tree,
+and two agents editing `web/src/app.css` at once is a merge conflict by
+construction.
+
+```
+Task 1  (own PR, before the branch)
+   │
+   ├─ branch cut ─────────────────────────────────────────────┐
+   │                                                          │
+Task 2  focus check (RED)                                  Task 8  docs site
+   │                                                       (docs.css only —
+Task 3  the five tokens  ──► Task 2 goes GREEN              no app.css, runs
+   │                                                        in parallel from
+   ├──► Task 4  typography                                  the branch cut)
+   ├──► Task 5  dashboard                                        │
+   ├──► Task 6  sidebar + select                                 │
+   │                                                             │
+Task 7a per-container overflow check (RED)                       │
+   │                                                             │
+Task 7b the 10 px and .col-port  ──► 7a goes GREEN               │
+   │                                                             │
+   └────────────────────┬────────────────────────────────────────┘
+                        │
+                   Task 9  DESIGN.md
+                        │
+                   Task 10 screenshots, carried-forward, roadmap, changelog
+```
+
+Tasks 4, 5, 6, 7a and 7b all edit `web/src/app.css`. Run them **sequentially**,
+or accept that whoever lands second rebases. Task 8 touches only `web/src/docs.css`,
+`docs/index.md` and the built docs stylesheet, so it is genuinely parallel.
+
+---
+
+## File structure
+
+| File | Responsibility in this release |
+|---|---|
+| `web/src/app.css` | the five-token replacement and every consumer; display voice; sidebar; tiles; language select; the two table fixes |
+| `web/static/style.css` | **committed build output.** Rebuilt in every task that edits `app.css`, and grepped |
+| `web/src/docs.css` | the parallel four-token replacement, mono `h1`, underlined links, the neutral hero |
+| `docs/assets/css/style.css` | **committed build output** of the above |
+| `web/templates/base.html` | version chip; the sidebar's active-item markup stays as it is (the divider is a `:has()` selector, no markup change) |
+| `web/templates/dashboard.html` | two ranks; `Manage →` removed six times; the update banner reworded |
+| `web/templates/ports.html` | `.chip-accent` → `.chip-select` |
+| `docs/index.md` | `.docs-hero-accent` renamed |
+| `internal/shared/version.go` | `ReleaseVersion`, so the topbar chip stops truncating a `git describe` string |
+| `internal/web/server.go` | `PageData.ReleaseVersion` |
+| `internal/web/accent_guard_test.go` | **new** — no accent token survives in either stylesheet |
+| `internal/web/version_chip_test.go` | **new** — the chip shows the release, the title the full string |
+| `scripts/ui-check.mjs` | the focus-contrast pass and the per-container overflow check |
+| `locales/{en,de,fr}.json` | `tile_manage` and `dashboard_running` removed |
+| `DESIGN.md` | the two replaced rules, the typography amendment, the colour tables, the components, the column rule, `Known Gaps` |
+| `docs/assets/img/screens/*` | all 36, re-taken |
+| `docs-tech/carried-forward.md`, `docs-tech/invariants.md`, `docs/_docs/roadmap.md`, `CHANGELOG.md` | the release's own record |
+
+---
+
+## Task 1: The `check:ui` language switch stops being racy
+
+**This lands as its own pull request, against `main`, before the 2.16 branch is
+cut.** Inside the branch it could not prove what predates it, which is the exact
+mistake 2.15 made.
+
+**Files:**
+- Modify: `scripts/ui-check.mjs:830-839` (`switchTo`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing. `switchTo(page, code)` keeps its signature — `async (page,
+  code) => boolean`, true when the POST completed.
+
+- [ ] **Step 1: Reproduce the race**
+
+`waitForRequest` resolves when the request is *issued*. The
+`waitForLoadState('load')` after it then returns against the still-current,
+already-loaded document, and `ctx.cookies()` is read before `Set-Cookie` has
+arrived. Prove it before fixing it, by making the server's answer slow:
+
+```bash
+scripts/demo-server.sh &
+node -e '
+const { chromium } = require("playwright-core");
+// Confirm the shape: waitForRequest resolves before the response exists.
+' # or simply reason from the source — the assertion below is the deliverable
+```
+
+The reproduction that matters is the one CI already produced: a green run
+locally and one red job reading `the POST went through but the cookie is unset`.
+Record that in the commit message rather than re-deriving it.
+
+- [ ] **Step 2: Make the wait a response wait**
+
+```javascript
+async function switchTo(page, code) {
+  // waitForResponse, not waitForRequest: the request resolving says the browser
+  // sent it, which is one round trip before Set-Cookie exists. The
+  // waitForLoadState below then returned against the document that was already
+  // loaded, and ctx.cookies() was read before the server had answered — green on
+  // a fast machine, red on a CI runner, which is exactly what it did.
+  const posted = page
+    .waitForResponse(r => r.url().endsWith('/language') && r.request().method() === 'POST',
+      { timeout: 5000 })
+    .then(() => true, () => false);
+  await page.locator('#lang-select').selectOption({ value: code });
+  const ok = await posted;
+  if (ok) await page.waitForLoadState('load');
+  return ok;
+}
+```
+
+- [ ] **Step 3: Correct the stale comment 50 lines below**
+
+`scripts/ui-check.mjs` line ~889 reads *"this one was never racy the way the
+change handler above was."* That is still true and now reads oddly beside a
+handler that is no longer racy either. Reword to name what makes the no-JS path
+different: `click()` auto-waits for the navigation a submit button starts, so it
+never needed the explicit wait the change handler does.
+
+- [ ] **Step 4: Run it**
+
+```bash
+scripts/demo-server.sh &
+npm run check:ui
+```
+Expected: `ok   the select submits itself on change with JavaScript running`
+and `ok   the submit button works with JavaScript disabled`, and the whole run
+exits 0.
+
+- [ ] **Step 5: Commit and open the pull request**
+
+```bash
+git switch -c fix/ui-check-language-switch-race main
+git add scripts/ui-check.mjs
+git commit -m "test(ui): the language switch waits for the response, not the request
+
+waitForRequest resolves when the browser sends the POST, which is one round
+trip before Set-Cookie exists. The waitForLoadState after it then returned
+against the document that was already loaded, and ctx.cookies() was read
+before the server had answered — green locally, red on a CI runner reporting
+\"the POST went through but the cookie is unset\"."
+gh pr create --base main --title "check:ui's language switch waits for the response"
+```
+
+Merge it before cutting the 2.16 branch.
+
+---
+
+## Task 2: The focus check, and it must be red
+
+The guard comes **before** the fix, because the spec measured what it should
+catch: a keyboard-focused `.input` in dark mode composites its outline at
+**1.31:1** against the card behind it. A guard written after the token swap
+proves nothing about the defect it exists for.
+
+**Files:**
+- Modify: `scripts/ui-check.mjs` — add `checkFocusIsVisible`, call it from `runChecks`
+
+**Interfaces:**
+- Consumes: `PAGES` (the 13 paths already declared at `scripts/ui-check.mjs:57`),
+  `fail(what, detail)`, `BASE`.
+- Produces: `async function checkFocusIsVisible(ctx, theme)` — walks every
+  focusable element on all 13 pages, composites the focus indicator against its
+  actual backdrop, and calls `fail()` below 3:1. Returns nothing.
+
+- [ ] **Step 1: Write the check**
+
+One width, both themes — focus colour does not vary with viewport, so this costs
+roughly 26 extra page passes rather than 130.
+
+```javascript
+/**
+ * Every focusable element shows where it is, at a contrast a person can see.
+ *
+ * WCAG 2.1 SC 1.4.11 Non-text Contrast (AA) wants 3:1 for a focus indicator
+ * against what is behind it. Measured rather than asserted against the
+ * stylesheet, and composited rather than read: the outline that shipped before
+ * this existed was `rgba(143,211,251,0.13)`, which is 11.4:1 as a *colour* and
+ * 1.31:1 once composited over the card it sits on. No number in a CSS file says
+ * that. (2.4.13 Focus Appearance is AAA and is not the criterion here; 2.4.11 is
+ * Focus Not Obscured and is a different question again.)
+ *
+ * The indicator is whichever of the two carries it — the outline, or the border
+ * change focus brings — so the check takes the better of the two and requires
+ * that one to clear 3:1. A control that answers focus with a border alone is
+ * fine; one that answers with neither is not.
+ */
+const RELATIVE_LUMINANCE = c => {
+  const s = c / 255;
+  return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+};
+
+function parseRGBA(str) {
+  const m = str.match(/rgba?\(([^)]+)\)/);
+  if (!m) return null;
+  const p = m[1].split(/[,\s/]+/).filter(Boolean).map(Number);
+  return { r: p[0], g: p[1], b: p[2], a: p.length > 3 ? p[3] : 1 };
+}
+
+function over(fg, bg) {
+  // Straight alpha composite of fg onto an opaque bg.
+  return {
+    r: fg.r * fg.a + bg.r * (1 - fg.a),
+    g: fg.g * fg.a + bg.g * (1 - fg.a),
+    b: fg.b * fg.a + bg.b * (1 - fg.a),
+  };
+}
+
+function contrast(a, b) {
+  const L = c => 0.2126 * RELATIVE_LUMINANCE(c.r) + 0.7152 * RELATIVE_LUMINANCE(c.g)
+    + 0.0722 * RELATIVE_LUMINANCE(c.b);
+  const [x, y] = [L(a), L(b)].sort((p, q) => q - p);
+  return (x + 0.05) / (y + 0.05);
+}
+
+async function checkFocusIsVisible(ctx, theme) {
+  const page = await ctx.newPage();
+  for (const path of PAGES) {
+    await page.goto(BASE + path, { waitUntil: 'networkidle' });
+
+    const measured = await page.evaluate(() => {
+      // The nearest ancestor that actually paints, which is what an indicator
+      // is seen against — not the element's own transparent background.
+      const backdrop = el => {
+        for (let n = el.parentElement; n; n = n.parentElement) {
+          const bg = getComputedStyle(n).backgroundColor;
+          const m = bg.match(/rgba?\(([^)]+)\)/);
+          if (!m) continue;
+          const p = m[1].split(/[,\s/]+/).filter(Boolean).map(Number);
+          if (p.length < 4 || p[3] > 0) return bg;
+        }
+        return getComputedStyle(document.body).backgroundColor;
+      };
+
+      const focusable = [...document.querySelectorAll(
+        'a[href], button, input:not([type=hidden]), select, textarea, [tabindex]:not([tabindex="-1"])',
+      )].filter(el => !el.disabled && el.offsetParent !== null);
+
+      const out = [];
+      for (const el of focusable) {
+        const before = getComputedStyle(el);
+        const rest = { outline: before.outlineColor, width: before.outlineWidth, border: before.borderTopColor };
+        el.focus();
+        const after = getComputedStyle(el);
+        out.push({
+          label: el.getAttribute('aria-label') || el.name || el.id || el.className || el.tagName,
+          outlineColor: after.outlineColor,
+          outlineWidth: parseFloat(after.outlineWidth) || 0,
+          borderBefore: rest.border,
+          borderAfter: after.borderTopColor,
+          backdrop: backdrop(el),
+        });
+        el.blur();
+      }
+      return out;
+    });
+
+    for (const m of measured) {
+      const bg = parseRGBA(m.backdrop);
+      if (!bg) continue;
+      const ratios = [];
+      if (m.outlineWidth > 0) {
+        const o = parseRGBA(m.outlineColor);
+        if (o) ratios.push(contrast(over(o, bg), bg));
+      }
+      if (m.borderAfter !== m.borderBefore) {
+        const b = parseRGBA(m.borderAfter);
+        if (b) ratios.push(contrast(over(b, bg), bg));
+      }
+      const best = ratios.length ? Math.max(...ratios) : 0;
+      if (best < 3) {
+        fail(`focus contrast [${theme}]`, `${path} — "${m.label}" focus indicator is ` +
+          `${best.toFixed(2)}:1 against its backdrop; WCAG 1.4.11 wants 3:1`);
+      }
+    }
+  }
+  console.log(`  ok   focus is visible on ${PAGES.length} pages in ${theme}`);
+  await page.close();
+}
+```
+
+- [ ] **Step 2: Call it, at one width in both themes**
+
+In `runChecks`, after the language switch and before the width loop:
+
+```javascript
+  // One width, both themes: focus colour does not vary with viewport, so this
+  // costs ~26 page passes rather than 130.
+  for (const theme of ['dark', 'light']) {
+    const focusCtx = await browser.newContext({
+      ignoreHTTPSErrors: true,
+      viewport: { width: 1600, height: 1000 },
+      storageState: session,
+    });
+    await focusCtx.addInitScript(t => localStorage.setItem('theme', `easywall-${t}`), theme);
+    await checkFocusIsVisible(focusCtx, theme);
+    await focusCtx.close();
+  }
+```
+
+- [ ] **Step 3: Run it and watch it fail**
+
+```bash
+scripts/demo-server.sh &
+npm run check:ui
+```
+Expected: **FAIL**, naming `.input`, `.toggle` and `.checkbox` at roughly
+`1.31:1` in dark. If it passes, the check is not measuring what the spec
+measured — do not proceed to Task 3 until it is red.
+
+- [ ] **Step 4: Commit the red guard**
+
+```bash
+git add scripts/ui-check.mjs
+git commit -m "test(ui): focus indicators are composited and required to clear 3:1
+
+Red on the current stylesheet: the keyboard-focus outline is
+rgba(143,211,251,0.13), which is 11.4:1 as a colour and 1.31:1 once composited
+over the card behind it. No number in a CSS file says that."
+```
+
+---
+
+## Task 3: Five tokens out, five in
+
+The declaration and every consumer in one commit, because a custom property that
+no longer exists renders as `transparent` rather than as an error — a half-done
+swap is an invisible one.
+
+**Files:**
+- Modify: `web/src/app.css` (all 72 matching lines)
+- Modify: `web/templates/ports.html:153` — `chip-accent` → `chip-select`
+- Modify: `web/static/style.css` — rebuilt, committed
+- Create: `internal/web/accent_guard_test.go`
+
+**Interfaces:**
+- Consumes: the token table in *Global Constraints*.
+- Produces: `--color-action-fill`, `--color-action-ink`, `--color-select-fill`,
+  `--color-select-edge`, `--color-focus-ring`, and the class `.chip-select`
+  (replacing `.chip-accent`). Tasks 4, 5 and 6 consume all six.
+
+- [ ] **Step 1: Write the guard first, and watch it fail**
+
+```go
+package web
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// No accent token survives, in either stylesheet.
+//
+// 2.16 removed the ice-blue accent because a page with it in fourteen places has
+// no accent at all — /settings carried exactly fourteen. What this guards is not
+// the removal but the return: a token reintroduced "just for this one case" six
+// months from now is a one-line diff nobody reads twice, and it puts a colour
+// back into a system whose entire remaining rule is that colour means firewall
+// state.
+//
+// Both the sources and the built files, because the two can disagree: Tailwind
+// drops rules silently, so a token present in web/src and absent from the built
+// output is a different defect from one present in both.
+func TestNoAccentTokenSurvives(t *testing.T) {
+	root := filepath.Dir(localesDir(t))
+
+	// The custom properties, not the word. `.docs-hero-accent` was a class name
+	// and is renamed in its own task; matching bare "accent" would fail on
+	// markup rather than on colour, which is not what this is about.
+	token := regexp.MustCompile(`--(color-)?accent[a-z-]*\b|--accent-wash\b`)
+
+	for _, f := range []string{
+		filepath.Join("web", "src", "app.css"),
+		filepath.Join("web", "src", "docs.css"),
+		filepath.Join("web", "static", "style.css"),
+		filepath.Join("docs", "assets", "css", "style.css"),
+	} {
+		raw, err := os.ReadFile(filepath.Join(root, f))
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		for i, line := range strings.Split(string(raw), "\n") {
+			// A comment may name the token it replaced; a declaration may not.
+			if strings.Contains(line, "/*") || strings.HasPrefix(strings.TrimSpace(line), "*") {
+				continue
+			}
+			if m := token.FindString(line); m != "" {
+				t.Errorf("%s:%d still names %q\n"+
+					"  colour means firewall state after 2.16; focus, selection and the "+
+					"primary action are carried by fill, edge and weight", f, i+1, m)
+			}
+		}
+	}
+}
+
+// And the retired literals the rename cannot reach: three chromatic values left
+// behind by earlier palettes, still hard-coded in docs.css where a token grep
+// walks straight past them.
+func TestNoRetiredHueSurvives(t *testing.T) {
+	root := filepath.Dir(localesDir(t))
+	for _, f := range []string{
+		filepath.Join("web", "src", "docs.css"),
+		filepath.Join("docs", "assets", "css", "style.css"),
+	} {
+		raw, err := os.ReadFile(filepath.Join(root, f))
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		for _, hue := range []struct{ literal, was string }{
+			{"34,211,238", "the retired Aurora cyan"},
+			{"8,145,178", "its light-mode twin"},
+			{"45,212,191", "the hero glow's teal"},
+		} {
+			if strings.Contains(string(raw), hue.literal) {
+				t.Errorf("%s still carries rgba(%s,…) — %s", f, hue.literal, hue.was)
+			}
+		}
+	}
+}
+```
+
+Run: `go test ./internal/web/ -run 'TestNoAccentTokenSurvives|TestNoRetiredHueSurvives' -v`
+Expected: **FAIL**, listing the token declarations in both source stylesheets and
+their built copies.
+
+- [ ] **Step 2: Replace the declarations**
+
+In `web/src/app.css`, the `@theme` block (dark, ~line 60):
+
+```css
+  /* Focus, selection and the one primary action are carried by fill, edge and
+     weight, not by hue. What is left of colour is state — see DESIGN.md's
+     rule 1, replaced in 2.16. */
+  --color-action-fill: #f1f3f6;
+  --color-action-ink: #0a0b0f;
+  --color-select-fill: #181b22;
+  --color-select-edge: #f1f3f6;
+  --color-focus-ring: #f1f3f6;
+```
+
+Delete `--color-accent`, `--color-accent-ink`, `--color-accent-on-wash`,
+`--color-accent-hover`. Delete `--accent-wash` from the `:root` alpha block
+(~line 85) — `select-fill` is an opaque scale entry and belongs in `@theme`.
+
+In the light block (~line 132), the same five:
+
+```css
+  --color-action-fill: #0f1116;
+  --color-action-ink: #ffffff;
+  --color-select-fill: #f4f6f9;
+  --color-select-edge: #0f1116;
+  --color-focus-ring: #0f1116;
+```
+
+and delete `--accent-wash` from the light alpha block (~line 143).
+
+- [ ] **Step 3: Rewrite every consumer**
+
+Work from `grep -n accent web/src/app.css` and finish at zero matches. The
+mapping, site by site:
+
+| Site | Was | Becomes |
+|---|---|---|
+| `.user-avatar` | `--accent-wash` / `--color-accent-on-wash` | `--color-surface-raised` / `--color-ink` — an avatar is a neutral marker, not a selection |
+| `.brand-icon`, `.auth-logo-mark` | `background-color: var(--color-accent)` | `var(--color-ink)` |
+| `.nav-links li.active a` | `--accent-wash` / `--color-accent-on-wash` | `--color-select-fill` / `--color-ink` |
+| `.nav-links li.active a::before` | `background: var(--color-accent)` | `var(--color-select-edge)` |
+| `.theme-toggle:focus-visible` | `outline: 2px solid var(--accent-wash)` | `2px solid var(--color-focus-ring)`, `outline-offset: 2px` |
+| `.lang-select:focus`, `:focus-visible` | outline `--accent-wash`, border `--color-accent` | outline and border both `--color-focus-ring` |
+| `.lang-submit:focus-visible` | same | same |
+| `:root[data-theme=light] .toggle-switch` | `--color-accent` / `--color-accent-ink` | `--color-action-fill` / `--color-action-ink` |
+| `.btn:focus-visible` | outline `--accent-wash`, border `--color-accent` | both `--color-focus-ring`, `outline-offset: 2px` |
+| `.btn-primary` | `--color-accent` / `--color-accent-ink` | `--color-action-fill` / `--color-action-ink` |
+| `.btn-primary:hover` | `--color-accent-hover` | `var(--color-ink-muted)` — see finding 4 |
+| `.btn-icon:focus-visible` | outline `--accent-wash`, border `--color-accent` | both `--color-focus-ring` |
+| `.input:focus`, `:focus-visible` | outline `--accent-wash`, border `--color-accent` | both `--color-focus-ring`, `outline-offset: 2px` |
+| `.input-cell:focus`, `:focus-visible` | same | same |
+| `.link` | `color: var(--color-accent-on-wash)` | `color: var(--color-ink); text-decoration: underline; text-underline-offset: 2px` |
+| `.link:hover` | `text-decoration: underline` | `text-decoration-thickness: 2px` |
+| `.link:focus-visible` | `outline: 2px solid var(--accent-wash)` | `2px solid var(--color-focus-ring)` |
+| `.tab.is-active` | `border-bottom-color: var(--color-accent)` | `var(--color-select-edge)` |
+| `a.chip:hover` | `border-color: var(--color-accent)` | `var(--color-ink)` |
+| `a.chip:focus-visible` | outline `--accent-wash`, border `--color-accent` | both `--color-focus-ring` |
+| `.chip-accent` | rename to `.chip-select` | bg `--color-select-fill`, colour `--color-ink`, border `--color-select-edge` |
+| `.toggle:checked` | `--color-accent` / `--color-accent-ink` | `--color-action-fill` / `--color-action-ink` |
+| `.toggle:focus-visible` | `outline: 2px solid var(--accent-wash)` | `2px solid var(--color-focus-ring)` (offset already 2px) |
+| `.checkbox::after` | borders `--color-accent-ink` | `--color-action-ink` |
+| `.checkbox:checked` | bg and border `--color-accent` | `--color-action-fill` |
+| `.checkbox:focus-visible` | `outline: 2px solid var(--accent-wash)` | `2px solid var(--color-focus-ring)` |
+| `.radio:checked` | border and inset ring `--color-accent` | `--color-select-edge` — a radio is a selection |
+| `.radio:focus-visible` | `outline: 2px solid var(--color-accent)` | `var(--color-focus-ring)` |
+| `.editor textarea:focus` | `outline: 2px solid var(--accent-wash)` | `2px solid var(--color-focus-ring)` (offset stays `-2px`) |
+| `a.stat-tile:hover` | `border-color: var(--color-accent)` | `var(--color-ink)` |
+| `a.stat-tile:focus-visible` | outline `--accent-wash`, border `--color-accent` | both `--color-focus-ring` |
+| `a.stat-tile:hover .stat-tile-icon` | `--color-accent-on-wash` | `var(--color-ink)` |
+| `a.stat-tile:hover .stat-tile-cta` | `--color-accent-on-wash` | `var(--color-ink)` — Task 5 deletes the rule entirely |
+| `.stat-tile-value-primary` | `--color-accent-on-wash` | **delete the rule**; nothing names the class |
+| `.module:has(.toggle:checked)` | `inset 2px 0 0 var(--color-accent)` | `var(--color-select-edge)` |
+| `.module:focus-within` | `border-color: var(--color-accent)` | `var(--color-focus-ring)` |
+| `.demo-chip-dot` | `background: var(--color-accent)` | `var(--color-ink-subtle)` — a demo marker is not a state |
+
+Two prose comments name the accent and must be rewritten rather than left
+lying: the block above `.page-header` (~line 620) and the one above `.link`.
+
+- [ ] **Step 4: Follow the rename into the template**
+
+`web/templates/ports.html:153`:
+
+```html
+              <span class="chip {{if eq (printf "%s" .Suggest) "private"}}chip-select{{else}}chip-warn{{end}}">
+```
+
+- [ ] **Step 5: Rebuild, and grep the built file**
+
+```bash
+npm run build:css
+grep -c accent web/static/style.css          # expected: 0
+grep -o -- '--color-focus-ring:[^;]*' web/static/style.css   # expected: two, one per theme
+grep -c 'chip-select' web/static/style.css   # expected: >= 1
+```
+
+A green build is not proof the rule shipped.
+
+- [ ] **Step 6: The guards go green, and Task 2's check with them**
+
+```bash
+go test ./internal/web/ -run 'TestNoAccentTokenSurvives|TestNoRetiredHueSurvives'
+```
+Expected: PASS for `app.css` and `web/static/style.css`. `TestNoRetiredHueSurvives`
+and the two docs files stay **red until Task 8** — that is correct, and it is why
+Task 8 is not optional. Skip the docs paths with `t.Skip` only if you are
+splitting the commit, and remove the skip in Task 8.
+
+```bash
+go test ./internal/web/ -run TestTemplateClassesExistInStylesheet
+scripts/demo-server.sh & npm run check:ui
+```
+Expected: the focus check from Task 2 now reports
+`ok   focus is visible on 13 pages in dark` and the same in light.
+
+- [ ] **Step 7: Verify by mutation**
+
+Put `--color-accent: #8fd3fb;` back into the `@theme` block and rebuild.
+`TestNoAccentTokenSurvives` must go red naming both the source and the built
+file. Then weaken `--color-focus-ring` to `rgba(241,243,246,0.13)`, rebuild, and
+`checkFocusIsVisible` must go red at roughly 1.3:1. Restore both.
+
+- [ ] **Step 8: Render it, both themes, three widths**
+
+Chrome extension, not Playwright — 1600, 900 and 390 px, dark and light, on
+`/dashboard`, `/ports`, `/options` and `/settings`. What you are looking for:
+the *on* toggles on `/options` read as clearly on (ink-filled: 16.72:1 dark,
+18.88:1 light, against 11.4:1 and 4.73:1 before), and the active nav item is
+identifiable by its edge and not only by its fill.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/src/app.css web/static/style.css web/templates/ports.html internal/web/accent_guard_test.go
+git commit -m "feat(design): the accent is removed; fill, edge and weight carry its jobs
+
+Five tokens out and five in, one for one. Colour now means firewall state and
+nothing else: a screen with no colour on it says the firewall has nothing to
+report. The on-state of a protection toggle does not weaken — ink-filled it is
+16.72:1 in dark and 18.88:1 in light, against 11.4:1 and 4.73:1 before."
+```
+
+---
+
+## Task 4: The display voice, and the two things that travel with it
+
+**Files:**
+- Modify: `web/src/app.css` — `.page-title`
+- Modify: `web/templates/dashboard.html` — the update banner and the removed subtitle
+- Modify: `web/templates/base.html` — the version chip
+- Modify: `internal/shared/version.go` — `ReleaseVersion`
+- Modify: `internal/web/server.go` — `PageData.ReleaseVersion`
+- Modify: `locales/{en,de,fr}.json` — `dashboard_running` removed
+- Create: `internal/web/version_chip_test.go`
+- Modify: `web/static/style.css` — rebuilt
+
+**Interfaces:**
+- Consumes: nothing from Task 3 beyond the rebuilt stylesheet.
+- Produces: `shared.ReleaseVersion(describe string) string`, and
+  `PageData.ReleaseVersion string`. Nothing later consumes them.
+
+- [ ] **Step 1: Write the failing test for the version helper**
+
+```go
+package web
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jp1337/easywall/internal/shared"
+)
+
+// The topbar chip renders `v2.14.0-44-g5…` today and reads as broken data.
+//
+// The Makefile passes `git describe --tags --always --dirty`, so a development
+// build's version is a tag plus a commit count plus an abbreviated sha. At 18ch
+// the chip truncates it, and an ellipsis in the chrome reads as a fault in the
+// software rather than as a build detail. The chip shows the release; the full
+// string moves to the title attribute, where a development build is still
+// recoverable.
+func TestReleaseVersionDropsTheDescribeSuffix(t *testing.T) {
+	for _, tc := range []struct{ in, want, why string }{
+		{"v2.15.1", "v2.15.1", "a tagged build is already the release"},
+		{"2.15.1", "2.15.1", "with or without the v"},
+		{"v2.14.0-44-g5abc123", "v2.14.0", "the commits-since-tag and the sha go"},
+		{"v2.15.1-dirty", "v2.15.1", "so does a dirty marker"},
+		{"v2.14.0-44-g5abc123-dirty", "v2.14.0", "and both together"},
+		{"v2.16.0-rc1", "v2.16.0-rc1", "a pre-release suffix is part of the tag and stays"},
+		{"v2.16.0-rc1-3-gdeadbee", "v2.16.0-rc1", "even with a describe suffix after it"},
+		{"5abc123", "5abc123", "`--always` with no tag in reach: nothing to trim"},
+		{"dev", "dev", "the Makefile's own fallback"},
+		{"", "", "and nothing at all is not a crash"},
+	} {
+		if got := shared.ReleaseVersion(tc.in); got != tc.want {
+			t.Errorf("ReleaseVersion(%q) = %q, want %q — %s", tc.in, got, tc.want, tc.why)
+		}
+	}
+}
+
+// And the chip renders the short form while the title keeps the long one. Both
+// halves matter: without the title a development build becomes unidentifiable
+// from the interface, which is worse than an ellipsis.
+func TestTheVersionChipShowsTheReleaseAndTitlesTheBuild(t *testing.T) {
+	root := filepath.Dir(localesDir(t))
+	raw, err := os.ReadFile(filepath.Join(root, "web", "templates", "base.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+
+	const want = `<span class="brand-version" title="{{.Version}}">{{.ReleaseVersion}}</span>`
+	if !strings.Contains(body, want) {
+		t.Errorf("base.html does not render the version chip as %s\n"+
+			"  the chip has to carry the release and the title the full `git describe` "+
+			"string; swapping them puts the ellipsis back", want)
+	}
+}
+```
+
+Run: `go test ./internal/web/ -run 'TestReleaseVersion|TestTheVersionChip' -v`
+Expected: FAIL — `shared.ReleaseVersion` undefined.
+
+- [ ] **Step 2: Implement it**
+
+In `internal/shared/version.go`:
+
+```go
+// describeSuffix matches what `git describe --tags --always --dirty` appends to
+// a tag: the number of commits since it, the abbreviated object name, and an
+// optional dirty marker. Anchored at the end so a pre-release tag — v2.16.0-rc1,
+// where the hyphen is part of the tag itself — survives.
+var describeSuffix = regexp.MustCompile(`(-\d+-g[0-9a-f]{4,40})?(-dirty)?$`)
+
+// ReleaseVersion is the release a build belongs to, without the build detail.
+//
+// The Makefile hands the linker `git describe --tags --always --dirty`, so a
+// development build reports something like v2.14.0-44-g5abc123. That is the
+// right thing for `--version` and the wrong thing for a 18ch chip in the
+// topbar, where it rendered as `v2.14.0-44-g5…` and read as broken data rather
+// than as a build detail. The chip shows this; the title attribute keeps the
+// full string, so a development build stays identifiable from the interface.
+//
+// Anything that is not a describe string is returned unchanged — an untagged
+// checkout answers `--always` with a bare object name, and the Makefile's own
+// fallback is the literal "dev".
+func ReleaseVersion(describe string) string {
+	return describeSuffix.ReplaceAllString(describe, "")
+}
+```
+
+Add `"regexp"` to the imports.
+
+In `internal/web/server.go`, beside `Version: shared.CurrentVersion,`:
+
+```go
+		Version:        shared.CurrentVersion,
+		ReleaseVersion: shared.ReleaseVersion(shared.CurrentVersion),
+```
+
+and add `ReleaseVersion string` to the `PageData` struct beside `Version`.
+
+- [ ] **Step 3: Render it in the template**
+
+`web/templates/base.html`, in `{{define "sidebar"}}`:
+
+```html
+    <span class="brand-version" title="{{.Version}}">{{.ReleaseVersion}}</span>
+```
+
+Leave `.brand-version`'s `max-width: 18ch` and its comment alone. The existing
+check *the version badge fits every version string a build can carry* sets
+`textContent` directly and still has to pass against the shortened form.
+
+- [ ] **Step 4: The display voice**
+
+In `web/src/app.css`, replace `.page-title`:
+
+```css
+  /* The page you are standing on is identified, not read — see DESIGN.md's
+     typography rule, amended in 2.16. The countdown proved this voice works and
+     it appeared on exactly one page.
+
+     30px is a ceiling reached by measurement, not a preference. The longest
+     page title across all three locales is 23 characters ("Changer le mot de
+     passe", fr) and wraps at its spaces; the longest *unbreakable* one is 19 —
+     "Systemeinstellungen", a German compound with no break point. JetBrains
+     Mono advances 0.6em, so 19 characters is 11.4em, and roughly 358px is
+     available inside the padding at a 390px viewport: 31.4px. Verify by
+     rendering /settings in German at 390px, not by trusting this arithmetic. */
+  .page-title {
+    margin: 0;
+    font-family: var(--font-data);
+    font-size: 30px;
+    font-weight: 300;
+    letter-spacing: -0.01em;
+  }
+
+  @media (min-width: 900px) {
+    .page-title { font-size: 34px; }
+  }
+```
+
+- [ ] **Step 5: Remove the `Running version …` line, and reword the banner**
+
+In `web/templates/dashboard.html`, the whole `{{if .Version}}{{if
+.Version.UpdateAvailable}}…{{else}}…{{end}}{{end}}` block currently uses
+`dashboard_running` twice. The `{{else}}` branch — the `<p class="page-subtitle
+mb-4">` — goes entirely: it repeats the topbar chip a few centimetres above the
+`h1`, and a label above a heading is the commonest generated-page tell. The
+banner keeps its job with the key it already has:
+
+```html
+    {{if .Version}}{{if .Version.UpdateAvailable}}
+    <div class="update-banner">
+      <svg viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/></svg>
+      <span>{{T "dashboard_update_available"}} <strong>{{.Version.Latest}}</strong></span>
+      <a href="{{.Version.ReleaseURL}}" target="_blank" rel="noopener">{{T "dashboard_view_release"}} &rarr;</a>
+    </div>
+    {{end}}{{end}}
+```
+
+The version you are on is in the topbar chip, three lines up and now legible;
+saying it again inside the banner was the same repetition the subtitle was.
+
+- [ ] **Step 6: Remove the key from all three locales**
+
+Delete the `dashboard_running` entry from `locales/en.json`, `locales/de.json`
+and `locales/fr.json`. `en`/`de` parity holds by construction because it leaves
+both.
+
+- [ ] **Step 7: Rebuild, run, grep**
+
+```bash
+npm run build:css
+grep -o '\.page-title{[^}]*}' web/static/style.css     # mono, 300, 30px
+grep -c 'dashboard_running' web/templates locales -r   # expected: 0
+go test ./internal/web/ ./internal/shared/
+```
+Expected: PASS, including `TestTemplatesOnlyUseTranslatedKeys` and
+`TestLocaleFilesAreAtParity`.
+
+- [ ] **Step 8: Verify by mutation**
+
+Change `ReleaseVersion` to `return describe` and
+`TestReleaseVersionDropsTheDescribeSuffix` must go red on five of its ten cases.
+Swap `{{.Version}}` and `{{.ReleaseVersion}}` in the template and
+`TestTheVersionChipShowsTheReleaseAndTitlesTheBuild` must go red. Restore both.
+
+- [ ] **Step 9: Render `/settings` in German at 390 px**
+
+This is the measurement the 30 px ceiling rests on. Chrome extension, dark and
+light, 390 px, language switched to Deutsch: `Systemeinstellungen` must sit on
+one line inside the padding. If it does not, the ceiling is wrong and the
+number moves — not the rule.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add web/src/app.css web/static/style.css web/templates/base.html \
+        web/templates/dashboard.html internal/shared/version.go \
+        internal/web/server.go internal/web/version_chip_test.go locales/
+git commit -m "feat(design): the page title takes the display voice, and the chip stops truncating
+
+JetBrains Mono 300 at 30/34px. Inter for what is read, mono for what is
+identified — the name of the page you are standing on is identified. The
+'Running version …' line above the dashboard h1 goes with it: it repeated the
+topbar chip a few centimetres above, and the chip now shows a release rather
+than an ellipsis."
+```
+
+---
+
+## Task 5: Two ranks, not one grid
+
+**Files:**
+- Modify: `web/templates/dashboard.html`
+- Modify: `web/src/app.css` — `.stat-tile*`, `.tile-grid`, new rank-two rules
+- Modify: `locales/{en,de,fr}.json` — `tile_manage` removed
+- Modify: `web/static/style.css` — rebuilt
+- Test: `internal/web/stat_tile_test.go` (existing; its span assertion moves 4 → 3)
+
+**Interfaces:**
+- Consumes: `--color-ink`, `--color-ink-subtle`, `--color-rule` from Task 3.
+- Produces: `.rule-list`, `.rule-list-row`, `.rule-list-count`, `.rule-list-note`
+  — the rank-two list. Nothing later consumes them.
+
+- [ ] **Step 1: Watch the existing guard tell you the shape changed**
+
+Before touching the stylesheet, remove one `<div class="stat-tile-cta">` from
+`dashboard.html` and run:
+
+```bash
+go test ./internal/web/ -run TestStatTileSpanMatchesItsChildren -v
+```
+Expected: FAIL — `stat tile 1 has 3 children but the stylesheet spans 4 rows`.
+That is the guard working. Put the line back and do the change properly.
+
+- [ ] **Step 2: Rank one — three tiles, and the finding promoted**
+
+In `dashboard.html`, keep **TCP ports**, **UDP ports** and **Port forwarding**
+as `a.stat-tile`. Delete the `<div class="stat-tile-cta">{{T "tile_manage"}}
+&rarr;</div>` from all six. The tile is already an `<a>`; an arrow announcing
+that a link is a link is decoration.
+
+The unused-port finding gets its own line under a hairline rather than sitting
+in the tile's smallest type. It is the most useful sentence on the page and the
+reason 2.15 happened:
+
+```html
+      <a href="/ports?type=tcp" class="stat-tile">
+        <div class="stat-tile-top">
+          <span class="stat-tile-label">{{T "dashboard_tcp_ports"}}</span>
+          <svg class="stat-tile-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M5.25 14.25h13.5m-13.5 0a3 3 0 01-3-3m3 3a3 3 0 100 6h13.5a3 3 0 100-6m-16.5-3a3 3 0 013-3h13.5a3 3 0 013 3"/></svg>
+        </div>
+        <div class="stat-tile-value">{{.Counts.TCP}}</div>
+        <div class="stat-tile-note">{{T "tile_tcp_note"}}</div>
+        {{if $.Data.UnusedTCP}}<div class="stat-tile-finding">{{T "tile_tcp_unused" (dict "N" $.Data.UnusedTCP)}}</div>{{end}}
+      </a>
+```
+
+**`.stat-tile-finding` is a conditional fourth child, and the subgrid spans a
+fixed number of rows.** That is precisely what `.tile-note-second` was invented
+to avoid. Keep the span at **3** and take the finding out of the subgrid flow:
+
+```css
+  /* The finding, under a hairline, in the tile's own footer. Positioned rather
+     than added as a fourth grid child: .stat-tile is a subgrid spanning a fixed
+     row count, so a conditional child gives the three tiles two different
+     heights — which is the defect .tile-note-second was written to avoid and
+     TestStatTileSpanMatchesItsChildren exists to catch. No colour: an unused
+     open port is none of live, unconfirmed, rolled back or failing. */
+  .stat-tile:has(.stat-tile-finding) { padding-bottom: 0; }
+
+  .stat-tile-finding {
+    grid-column: 1 / -1;
+    margin: 10px -15px 0;
+    padding: 8px 15px;
+    border-top: 1px solid var(--color-rule);
+    font-size: 12px;
+    color: var(--color-ink-muted);
+  }
+```
+
+Delete `.stat-tile-cta`, `a.stat-tile:hover .stat-tile-cta` and
+`.tile-note-second` from the stylesheet, and change `grid-row: span 4` to
+`grid-row: span 3`.
+
+Update the `.stat-tile` comment: it says "four rows … label, value, note and
+CTA" and now describes three.
+
+- [ ] **Step 3: Rank two — a list, not a card**
+
+Three numbers are not three states. No border, no radius, no icon.
+
+```html
+      <div class="rule-list">
+        <a class="rule-list-row" href="/blacklist">
+          <span class="rule-list-name">{{T "dashboard_blacklist"}}</span>
+          <span class="rule-list-count">{{.Counts.Blacklist}}</span>
+          <span class="rule-list-note">{{T "tile_blacklist_note"}}</span>
+        </a>
+        <a class="rule-list-row" href="/whitelist">
+          <span class="rule-list-name">{{T "dashboard_whitelist"}}</span>
+          <span class="rule-list-count">{{.Counts.Whitelist}}</span>
+          <span class="rule-list-note">{{T "tile_whitelist_note"}}</span>
+        </a>
+        <a class="rule-list-row" href="/custom">
+          <span class="rule-list-name">{{T "dashboard_custom"}}</span>
+          <span class="rule-list-count">{{.Counts.Custom}}</span>
+          <span class="rule-list-note">{{T "tile_custom_note"}}</span>
+        </a>
+      </div>
+```
+
+```css
+  /* ── Rank two ────────────────────────────────────────────────────────────
+     The six tiles were never six of the same thing: three are ways into the
+     host and three change what the rules are. One grid claimed otherwise.
+     These are a list — no border, no radius, no icon — because three numbers
+     are not three states. */
+  .rule-list { display: flex; flex-direction: column; margin-top: 4px; }
+
+  .rule-list-row {
+    display: grid;
+    grid-template-columns: minmax(0, 12rem) 3.5rem minmax(0, 1fr);
+    align-items: baseline;
+    gap: 0 16px;
+    padding: 9px 4px;
+    border-bottom: 1px solid var(--color-rule);
+    color: inherit;
+    text-decoration: none;
+    font-size: 13px;
+    transition: background var(--motion-instant) var(--motion-ease);
+  }
+
+  .rule-list-row:last-child { border-bottom: 0; }
+  .rule-list-row:hover { background: var(--color-surface-raised); text-decoration: none; }
+
+  .rule-list-row:focus-visible {
+    outline: 2px solid var(--color-focus-ring);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
+  }
+
+  .rule-list-count {
+    font-family: var(--font-data);
+    font-variant-numeric: tabular-nums;
+    font-weight: 550;
+    text-align: right;
+  }
+
+  .rule-list-note { color: var(--color-ink-subtle); font-size: 12.5px; }
+
+  /* A phone has no room for three columns of unequal weight. The number keeps
+     its own line beside the name; the note drops beneath both. */
+  @media (max-width: 560px) {
+    .rule-list-row { grid-template-columns: minmax(0, 1fr) auto; }
+    .rule-list-note { grid-column: 1 / -1; }
+  }
+```
+
+- [ ] **Step 4: The orphan comment on `.tile-grid` dissolves**
+
+With three tiles in rank one there is no row to strand. Rewrite the comment
+above `minmax(168px, 1fr)` — it worries about one stray tile per row, which was
+a six-tile problem. Keep the 168px; the measurement behind it (at 190 a 390 px
+phone fell to one column) still holds.
+
+- [ ] **Step 5: Remove `tile_manage` from all three locales**
+
+- [ ] **Step 6: Rebuild, test, grep**
+
+```bash
+npm run build:css
+grep -c 'stat-tile-cta\|tile-note-second' web/static/style.css   # expected: 0
+grep -o 'grid-row:span [0-9]' web/static/style.css               # expected: span 3
+grep -rc 'tile_manage' web/templates locales                     # expected: 0
+go test ./internal/web/
+```
+Expected: PASS, including `TestStatTileSpanMatchesItsChildren`,
+`TestStatTileRowsComeFromTheGrid`, `TestTemplateClassesExistInStylesheet` and
+`TestDashboard_CountsTheTCPPortsNobodyHasUsed`.
+
+- [ ] **Step 7: Verify by mutation**
+
+Set `grid-row: span 4` and rebuild — `TestStatTileSpanMatchesItsChildren` goes
+red. Delete `.rule-list-count` from the stylesheet and rebuild —
+`TestTemplateClassesExistInStylesheet` goes red. Restore both.
+
+- [ ] **Step 8: Render it**
+
+Chrome extension, `/dashboard`, dark and light, 1600 / 900 / 390. In German
+too — `tile_tcp_unused` reads *"1 seit 30+ Tagen ungenutzt"* and the finding
+line is where a wrap would show. What you are checking: the three tiles are one
+even row at every width, the finding sits under its hairline, and rank two
+reads as a list rather than as three cards that lost their borders.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/templates/dashboard.html web/src/app.css web/static/style.css locales/
+git commit -m "feat(dashboard): two ranks, not one grid, and 'Manage →' goes six times
+
+Three of the six tiles are ways into the host and three change what the rules
+are; one grid said they were the same thing. The tile is already an <a>, so an
+arrow announcing that a link is a link was decoration. The unused-port finding
+— the most useful sentence on the page, and the reason 2.15 happened — moves
+out of the tile's smallest type onto its own line under a hairline."
+```
+
+---
+
+## Task 6: The sidebar's divider and indent, and the one native control
+
+**Files:**
+- Modify: `web/src/app.css` — `.nav-section`, `.nav-links`, `.lang-select`
+- Modify: `web/static/style.css` — rebuilt
+- Create: `internal/web/nav_group_test.go`
+
+**Interfaces:**
+- Consumes: `--color-select-fill`, `--color-select-edge`, `--color-focus-ring`,
+  `--color-rule`, `--color-surface-raised` from Task 3.
+- Produces: nothing consumed later. **No markup change** — the divider and the
+  indent are `:has()` selectors over the existing three `.nav-section` blocks, so
+  a fourth group added to `base.html` gets both for free.
+
+- [ ] **Step 1: Write the failing guard**
+
+```go
+package web
+
+import (
+	"strings"
+	"testing"
+)
+
+// The application sidebar gets the divider and the indent the documentation
+// sidebar was given, and for the reason DESIGN.md already states: a
+// nav-section-label at ink-subtle and a nav link at ink-muted sit twelve steps
+// apart per channel — distinct on paper, the same grey once rendered, with the
+// label the *lighter* of the two. Colour never carried the separation, and after
+// 2.16 there is even less of it to carry anything.
+//
+// carried-forward.md recorded this as "deliberately not touched" across three
+// design reviews. It is the entry 2.16 exists to close.
+//
+// Selector-shaped rather than markup-shaped on purpose: the rules hang off
+// :has(> .nav-section-label), so a fourth nav group added to base.html gets the
+// divider and the indent without anyone remembering to add a class.
+func TestTheSidebarGroupsCarryADividerAndAnIndent(t *testing.T) {
+	css := appStylesheet(t)
+
+	for _, want := range []struct{ needle, breaks string }{
+		{".nav-section:has(>.nav-section-label)~.nav-section:has(>.nav-section-label)",
+			"a labelled group that follows another labelled group has no rule above it, " +
+				"so Rules and System run together as one column of equal-weight text"},
+		{"padding-left:22px",
+			"the links under a label are not indented, so the eye reads two rows of " +
+				"equal-weight text instead of container-then-contents"},
+	} {
+		if !strings.Contains(css, want.needle) {
+			t.Errorf("web/static/style.css has no %q\n  without it: %s\n"+
+				"  rebuild with `npm run build:css` — Tailwind drops rules silently",
+				want.needle, want.breaks)
+		}
+	}
+
+	// The first labelled group must NOT get one: it follows Dashboard, not
+	// another group. The docs sidebar does exactly this with
+	// .nav-group:first-of-type. A sibling combinator is what expresses it, so
+	// a plain `.nav-section:has(...)` with a border-top is the mistake to catch.
+	if strings.Contains(css, ".nav-section:has(>.nav-section-label){border-top") {
+		t.Error("every labelled group carries a border-top, including the first\n" +
+			"  it follows the ungrouped Dashboard link, and a rule there divides nothing")
+	}
+}
+
+// The active nav item is never marked by a background alone.
+//
+// select-fill is 1.08:1 against surface in both themes — the same invisibility
+// as the focus ring this release replaced, measured at 1.31:1. The edge is what
+// says "this one is active"; the fill only confirms it.
+func TestTheActiveNavItemCarriesAnEdgeAndNotOnlyAFill(t *testing.T) {
+	css := appStylesheet(t)
+
+	if !strings.Contains(css, "--color-select-edge") {
+		t.Fatal("the built stylesheet has no --color-select-edge at all")
+	}
+	// The 2px edge lives on the ::before of the active link.
+	i := strings.Index(css, ".nav-links li.active a::before")
+	if i < 0 {
+		t.Fatal("the active nav item has no ::before rule — the edge is gone, and a " +
+			"fill at 1.08:1 against its surface is not a marker")
+	}
+	rule := css[i:]
+	if j := strings.Index(rule, "}"); j > 0 {
+		rule = rule[:j]
+	}
+	if !strings.Contains(rule, "var(--color-select-edge)") {
+		t.Errorf("the active item's edge is not select-edge: %q", rule)
+	}
+}
+```
+
+Run: `go test ./internal/web/ -run 'TestTheSidebarGroups|TestTheActiveNavItem' -v`
+Expected: FAIL on the first two needles.
+
+- [ ] **Step 2: The divider and the indent**
+
+In `web/src/app.css`, after `.nav-section-label`:
+
+```css
+  /* ── Group divider and indent ────────────────────────────────────────────
+     The device the documentation sidebar already has, for the reason DESIGN.md
+     already gives: label and link sit twelve steps apart per channel, which is
+     distinct on paper and the same grey once rendered — with the label the
+     lighter of the two, so it read as the weaker element rather than as the
+     divider it is. With no accent left, colour carries even less.
+
+     Sibling-scoped rather than class-scoped: the first labelled group follows
+     the ungrouped Dashboard link, not another group, and a rule there would
+     divide nothing. :has() means base.html needs no class, and a fourth group
+     added later gets both devices without anyone remembering to. */
+  .nav-section:has(> .nav-section-label) ~ .nav-section:has(> .nav-section-label) {
+    margin-top: 6px;
+    padding-top: 12px;
+    border-top: 1px solid var(--color-rule);
+  }
+
+  /* Container, then contents. The active edge stays in the gutter at the ul's
+     own padding, so it marks the group's left edge rather than the text's. */
+  .nav-section:has(> .nav-section-label) .nav-links li a { padding-left: 22px; }
+```
+
+- [ ] **Step 3: The active item, edge and fill**
+
+The rules from Task 3 stay as they are — `background: var(--color-select-fill)`,
+`color: var(--color-ink)`, `::before { background: var(--color-select-edge) }` at
+`width: 2px` and `left: -8px`. Confirm the `::before` was not lost in the token
+sweep; it is the load-bearing half.
+
+- [ ] **Step 4: The language `<select>`**
+
+It is the only native control in the interface, and on the login card it is
+recognisable only by its native arrow. `DESIGN.md` names the failure itself: a
+field's `canvas` background sits 1.03–1.06:1 from the `surface` of the card it
+is on.
+
+```css
+  .lang-select {
+    flex: 1;
+    min-width: 0;
+    height: var(--control-height-sm);
+    /* Room for the chevron below; the field's text must not run under it. */
+    padding: 0 26px 0 6px;
+    /* surface-raised, not canvas: on the login card a canvas fill sits
+       1.03–1.06:1 from the card behind it, so the control had no body of its
+       own and the native arrow was the only thing identifying it. */
+    background: var(--color-surface-raised);
+    color: var(--color-ink);
+    border: 1px solid var(--color-control-edge);
+    border-radius: var(--radius-sm);
+    font-family: var(--font-ui);
+    font-size: 12px;
+    cursor: pointer;
+    /* The one native control in the interface, drawn like the rest of them. */
+    appearance: none;
+    transition: border-color var(--motion-fast) var(--motion-ease);
+  }
+
+  /* The chevron. Two borders on an empty box rather than an icon file or a
+     data: URI — it takes currentColor, so it follows the theme with no second
+     asset, and style-src 'self' has nothing to object to. The same device the
+     documentation sidebar's group markers already use.
+
+     On the wrapper, not the select: a <select> cannot carry a reliable
+     pseudo-element. .lang-switch is the form, and the chevron is positioned
+     against the select's own right edge rather than the form's, so the no-JS
+     submit button beside it does not push it off. */
+  .lang-switch { position: relative; }
+
+  .lang-switch::after {
+    content: "";
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    width: 0.4rem;
+    height: 0.4rem;
+    margin-top: -0.3rem;
+    border-right: 1.5px solid var(--color-ink-subtle);
+    border-bottom: 1.5px solid var(--color-ink-subtle);
+    transform: rotate(45deg);
+    pointer-events: none;
+  }
+
+  /* With the submit button drawn — the no-JS path — the select is no longer
+     the last thing in the row, so the chevron has to move in front of it. */
+  .lang-switch:has(.lang-submit:not([hidden])) ::after { /* see step 5 */ }
+```
+
+- [ ] **Step 5: Settle the chevron's position against the no-JS button**
+
+`[data-js="on"] .lang-submit { display: none }` already exists, so with a script
+running the select **is** the last element and `right: 12px` is correct. Without
+a script the button sits to its right and the chevron would land on the button.
+Rather than a second selector, anchor the chevron to the select itself by
+wrapping nothing and using the `:has` the stylesheet already permits:
+
+```css
+  /* Without a script the submit button sits to the right of the select, so the
+     chevron has to clear it. Measured, not assumed: .lang-submit is
+     auto-width — render /login with JavaScript disabled and read the offset
+     off the page rather than adding up padding here. */
+  html:not([data-js]) .lang-switch::after {
+    right: calc(12px + var(--lang-submit-width, 4.5rem));
+  }
+```
+
+Delete the placeholder line from step 4 and keep only this one. **Verify the
+`4.5rem` fallback by rendering `/login` with JavaScript disabled** — Playwright's
+`javaScriptEnabled: false` context in `checkLanguageSwitch` is already doing
+this, so the number is checkable there.
+
+- [ ] **Step 6: Rebuild, test, grep**
+
+```bash
+npm run build:css
+grep -c 'appearance:none' web/static/style.css                  # >= 1 (.lang-select)
+grep -o '.nav-section:has([^)]*)~[^{]*{[^}]*}' web/static/style.css
+go test ./internal/web/ -run 'TestTheSidebarGroups|TestTheActiveNavItem'
+```
+Expected: PASS.
+
+- [ ] **Step 7: Verify by mutation**
+
+Delete the `~` from the divider selector so every labelled group gets a rule,
+rebuild, and the third assertion in `TestTheSidebarGroupsCarryADividerAndAnIndent`
+goes red. Delete the `::before` rule and
+`TestTheActiveNavItemCarriesAnEdgeAndNotOnlyAFill` goes red. Restore both.
+
+- [ ] **Step 8: Render it**
+
+Chrome extension: `/dashboard` and `/settings`, dark and light, 1600 / 900 / 390.
+At 390 the sidebar is a drawer — open it. Also `/login` signed out, where the
+language select sits on the auth card and is the whole point of the fill change.
+What you are checking: *Dashboard* has no rule above it, *Rules* has none either,
+*System* does; the grouped links are visibly indented under their labels; the
+active item is identifiable by its left edge with the page zoomed out far enough
+that the fill is not readable.
+
+**If the maintainer meant the diagram rather than the prose** (finding 2), the
+change is to drop the `~ .nav-section:has(> .nav-section-label)` half of the
+selector. Raise it in the pull request either way.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/src/app.css web/static/style.css internal/web/nav_group_test.go
+git commit -m "feat(sidebar): the divider and indent the documentation sidebar was given
+
+Three design reviews deferred this and carried-forward.md recorded it as
+deliberately not touched. Label and link sit twelve steps apart per channel —
+distinct on paper, the same grey once rendered — and after 2.16 there is even
+less colour to carry it. The language select stops being the one native control
+in the interface."
+```
+
+---
+
+## Task 7a: Find out why the overflow check is blind
+
+Two steps, in this order, **and not merged**. The deliverable here is a stronger
+check, not a fix. `carried-forward.md` warns that a fix which only silences the
+symptom leaves the check still blind.
+
+**Files:**
+- Modify: `scripts/ui-check.mjs` — `checkPageHealth`
+
+**Interfaces:**
+- Consumes: `PAGES`, `fail`, `BASE`.
+- Produces: `async function checkContainersDoNotOverflow(page, where, path)` —
+  called from `checkPageHealth` alongside `checkNoInputClipsItsOwnValue`.
+
+- [ ] **Step 1: Establish the blind spot before writing anything**
+
+`.table-wrap` overflows by 10 px in card mode at every width where the container
+query switches, and `npm run check:ui` does not fire. Read
+`checkPageHealth`: it measures
+
+```javascript
+document.documentElement.scrollWidth - document.documentElement.clientWidth
+```
+
+`.table-wrap` sets `overflow-x: auto`. A container that scrolls **absorbs** its
+own overflow — the document never widens, so a page-level measurement cannot see
+it, by construction. Confirm this in the browser rather than from the source:
+
+```bash
+scripts/demo-server.sh &
+# Chrome extension, /ports at 900px, then in the console:
+#   const w = document.querySelector('.table-wrap');
+#   [w.scrollWidth, w.clientWidth, w.scrollWidth - w.clientWidth]
+```
+Expected: a difference of about 10, with `document.documentElement.scrollWidth
+=== clientWidth`. **Record the measured numbers in the commit message.** This is
+a class of blind spot rather than one instance: every `overflow-x: auto`
+container in the stylesheet is invisible to the page-level check.
+
+- [ ] **Step 2: Write the per-container check**
+
+```javascript
+/**
+ * Nothing scrolls sideways inside its own container either.
+ *
+ * The page-level overflow check above cannot see this, and not by oversight: a
+ * container with `overflow-x: auto` absorbs its own overflow, so the document
+ * never widens. Every such container in the stylesheet was therefore
+ * unmeasured — .table-wrap, .scroll-wrapper, .content-body pre — and
+ * .table-wrap overflowed by 10px in card mode at every width the container
+ * query switches at, with this suite green throughout.
+ *
+ * A tolerance of 1px, not 0: sub-pixel layout rounds, and a check that fires on
+ * 0.5px is a check somebody switches off.
+ */
+async function checkContainersDoNotOverflow(page, where, path) {
+  const overflowing = await page.evaluate(() => {
+    const out = [];
+    for (const el of document.querySelectorAll('*')) {
+      const style = getComputedStyle(el);
+      if (style.overflowX !== 'auto' && style.overflowX !== 'scroll') continue;
+      // A container that scrolls because its *content* is genuinely wider — a
+      // table with more columns than fit — is doing its job. What this catches
+      // is a container narrower than its own laid-out children: the row is
+      // 10px wider than the box that holds it and nothing asked for that.
+      const child = [...el.children].reduce((w, c) => Math.max(w, c.scrollWidth), 0);
+      const over = child - el.clientWidth;
+      if (over > 1) {
+        out.push({
+          selector: el.className || el.tagName,
+          clientWidth: el.clientWidth,
+          contentWidth: child,
+          over,
+        });
+      }
+    }
+    return out;
+  });
+  for (const o of overflowing) {
+    fail(`container overflow [${where}]`, `${path} — .${o.selector} is ` +
+      `${o.clientWidth}px and holds ${o.contentWidth}px, ${o.over}px over`);
+  }
+}
+```
+
+- [ ] **Step 3: Call it**
+
+In `checkPageHealth`, immediately after `await checkNoInputClipsItsOwnValue(page, where, path);`:
+
+```javascript
+    await checkContainersDoNotOverflow(page, where, path);
+```
+
+It runs at all five widths in both themes, because a container query's
+behaviour is exactly what varies with width.
+
+- [ ] **Step 4: Run it, and it must be red**
+
+```bash
+scripts/demo-server.sh &
+npm run check:ui
+```
+Expected: **FAIL**, naming `.table-wrap` at roughly 10 px over, on `/ports`,
+`/forwarding` and `/log`, at the widths where the container query has switched
+to cards. If it is green, the check is not measuring what
+`carried-forward.md` measured — do not proceed to 7b.
+
+- [ ] **Step 5: Commit the red check on its own**
+
+```bash
+git add scripts/ui-check.mjs
+git commit -m "test(ui): overflow is measured per container, not only per page
+
+A container with overflow-x: auto absorbs its own overflow, so the document
+never widens and the page-level check cannot see it — by construction, for
+every such container in the stylesheet. .table-wrap has been 10px over in card
+mode at every width the container query switches at, with this suite green.
+
+Red on the current stylesheet. The fix is the next commit, deliberately not
+this one: a fix that only silenced the symptom would leave the check blind."
+```
+
+---
+
+## Task 7b: The 10 px and the 2 px
+
+**Files:**
+- Modify: `web/src/app.css` — `.table-reflow tr` / `.col-port`
+- Modify: `web/static/style.css` — rebuilt
+
+**Interfaces:**
+- Consumes: Task 7a's `checkContainersDoNotOverflow`, which must be red on entry
+  and green on exit.
+- Produces: nothing.
+
+- [ ] **Step 1: Find the 10 px**
+
+`carried-forward.md` measured it as identical with six, five and four columns
+and unchanged with `white-space: nowrap` removed, so it is neither the *Last
+used* column nor a wrapping problem: **something inside the card layout is 10 px
+wider than the container it sits in.** The first candidate to measure, not to
+assume:
+
+```css
+  .table-reflow tr {
+    margin: 10px;          /* ← left + right margin inside a 100%-width box */
+    ...
+  }
+```
+
+`.table-reflow tr` is `display: block; width: 100%`, and a 10 px margin on each
+side of a full-width block is 20 px of demand against a container that offers
+none. Measure it in the browser before changing it — the number to confirm is
+whether the observed overflow is 10 or 20, because that decides whether the
+margin is the whole cause or half of it.
+
+- [ ] **Step 2: Fix it at the cause**
+
+```css
+  .table-reflow tr {
+    /* Block margin only. A horizontal margin on a width:100% block asks the
+       container for 10px it does not have on either side, which is the 10px
+       .table-wrap has been scrolling since the card layout was written. The
+       inset the cards want comes from the container's padding instead, where
+       it is part of the box rather than added to it. */
+    margin: 10px 0;
+    padding: 4px 0;
+    background: var(--color-surface-raised);
+    border: 1px solid var(--color-rule);
+    border-radius: var(--radius-lg);
+  }
+```
+
+and give the wrap the inset the cards lost:
+
+```css
+@container (max-width: 940px) {
+  .table-wrap { padding-inline: 10px; }
+  ...
+}
+```
+
+If the measurement in step 1 says otherwise, follow the measurement — the
+deliverable is a green per-container check, not this particular edit.
+
+- [ ] **Step 3: `.col-port` is 120 px and `8000:9000` needs 122**
+
+`carried-forward.md` says the fix needs a decision `DESIGN.md` does not answer.
+It is already answered four declarations below, in `.col-toggle`'s own comment:
+*"Every pixel given back goes to `.col-flex`."* `.col-flex` is `width: auto` and
+absorbs the remainder, so there is no zero-sum choice to make.
+
+```css
+  /* 128px, not 120: the widest value the field's own placeholder documents is a
+     range, "8000:9000", which needs 122px and clipped. Sized by the widest
+     documented value measured rendered, not added up on paper — the rule
+     DESIGN.md gained in 2.16. .col-flex is width:auto and absorbs the
+     remainder, so nothing is taken from another column to pay for it. */
+  .col-port    { width: 128px; }
+```
+
+Verify the 128 by rendering, not by arithmetic: `8000:9000` in the port field on
+`/ports` at 1600 px, both themes, must not clip.
+
+- [ ] **Step 4: The check goes green**
+
+```bash
+npm run build:css
+scripts/demo-server.sh &
+npm run check:ui
+```
+Expected: no `container overflow` failures at any of the five widths in either
+theme, and no `input overflow` on `.col-port`.
+
+- [ ] **Step 5: Verify by mutation**
+
+Put `margin: 10px` back, rebuild, and `checkContainersDoNotOverflow` must go red
+at roughly 10 px. Put `.col-port` back to 120 px and
+`checkNoInputClipsItsOwnValue` must go red on the range. Restore both.
+
+- [ ] **Step 6: Render it**
+
+`/ports`, `/forwarding` and `/log`, dark and light, at 1600 / 900 / 390. At 900
+and 390 the tables are in card mode, which is where the 10 px lived. What you
+are checking: the cards sit inside their container with an even inset on both
+sides, and nothing scrolls sideways.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/app.css web/static/style.css
+git commit -m "fix(tables): the card layout's 10px, and .col-port's 2px
+
+Both entries carried forward from 2.15, closed here where the tables are the
+subject rather than a passenger. A horizontal margin on a width:100% block asks
+its container for room it does not have; the inset moves to the container's own
+padding. .col-port goes to 128px because 8000:9000 needs 122 — .col-flex is
+width:auto and absorbs the remainder, so no other column pays for it."
+```
+
+---
+
+## Task 8: The documentation site follows
+
+Parallel with Tasks 2–7: it touches `web/src/docs.css`, `docs/index.md` and the
+built docs stylesheet, and nothing else.
+
+**Files:**
+- Modify: `web/src/docs.css` (all 61 matching lines, plus nine literal hues)
+- Modify: `docs/index.md:22` — `.docs-hero-accent` renamed
+- Modify: `docs/assets/css/style.css` — rebuilt, committed
+- Modify: `internal/web/accent_guard_test.go` — remove any `t.Skip` left by Task 3
+
+**Interfaces:**
+- Consumes: nothing from the application tasks. Its tokens are named
+  differently and there are four of them, so this is a parallel replacement
+  rather than the same patch applied twice.
+- Produces: `--focus-ring`, `--link-ink`, `--select-fill`, `--select-edge`, and
+  the class `.docs-hero-mark`.
+
+- [ ] **Step 1: Replace the four tokens**
+
+`:root` (dark, ~line 76):
+
+```css
+  /* Colour means state, and the documentation has no firewall state — so it has
+     no colour. Links carry underline and weight instead of hue; see DESIGN.md,
+     where the reasoning is stated for both surfaces so they do not look like an
+     accident. */
+  --focus-ring:   #f1f3f6;
+  --link-ink:     #f1f3f6;
+  --select-fill:  #181b22;
+  --select-edge:  #f1f3f6;
+```
+
+`[data-theme="easywall-light"]` (~line 105):
+
+```css
+  --focus-ring:   #0f1116;
+  --link-ink:     #0f1116;
+  --select-fill:  #f4f6f9;
+  --select-edge:  #0f1116;
+```
+
+Delete `--accent`, `--accent-on`, `--accent-dim`, `--accent-hover` from both.
+
+**`--code-keyword: #8fd3fb` stays.** Syntax highlighting is its own semantic
+domain — the stylesheet's own comment says so — and a docs page carries no
+firewall state for the hue to collide with. It happens to share the retired
+accent's value, which is why the guard greps token *names* and not hexadecimal.
+
+- [ ] **Step 2: Rewrite the consumers**
+
+Work from `grep -n accent web/src/docs.css` to zero. The mapping:
+
+| Site | Becomes |
+|---|---|
+| `::selection` | `background: var(--select-fill)` |
+| `.topbar-logo:hover`, `.topbar-github:hover`, `.sidebar-logo:hover` | `color: var(--text)` |
+| `.sidebar-github:hover` | `color: var(--text)`, `background: var(--select-fill)` |
+| `.nav-link.active` | `background: var(--select-fill)`, `color: var(--text)`, and a `border-left: 2px solid var(--select-edge)` — the same "fill confirms, edge marks" rule the application takes |
+| `.docs-search-trigger:hover` / `:focus-visible` | `border-color: var(--focus-ring)`, `outline: 2px solid var(--focus-ring)` |
+| `.nav-group-label:focus-visible` | `outline: 2px solid var(--focus-ring)` |
+| `.theme-toggle:hover` | `border-color: var(--text-subtle)` |
+| `.sidebar-version` | `color: var(--text-muted)`, `background: var(--surface-2)`, `border: 1px solid var(--border)` — and the two literal `rgba(34,211,238,0.25)` / `rgba(8,145,178,0.25)` borders go |
+| `.page-footer a:hover` | `color: var(--text)` |
+| `.docs-hero-glow` | `radial-gradient(… var(--select-fill) …)` for the first stop; **delete the second gradient** — `rgba(45,212,191,0.08)` is teal and there is no token it maps to |
+| `.docs-hero-pill` | `background: var(--select-fill)`, `color: var(--text-muted)`, `border: 1px solid var(--border)`; the two literal rgba borders go |
+| `.docs-hero-pill-dot` | `background: var(--text-subtle)`, `box-shadow: 0 0 0 3px var(--select-fill)` |
+| `.docs-hero-accent` | renamed `.docs-hero-mark`; delete the gradient, the `background-clip`, the `-webkit-text-fill-color` and the `@supports` fallback, and set `color: var(--text)` — a gradient made of one colour twice is a colour |
+| `.docs-why-icon-solution` | `background: var(--select-fill)`, `color: var(--text-muted)` |
+| `.docs-design-row-num` | `color: var(--text-muted)`, `background: var(--select-fill)`, `border: 1px solid var(--border)`; both literal rgba borders go |
+| `.docs-cta-glow` | first stop `var(--select-fill)`; **delete the teal second gradient** |
+| `.docs-cta-credentials code` | `color: var(--text)`, `background: var(--surface-2)` |
+| `.feature-card:hover` | `border-color: var(--border)` |
+| `#docs-search-panel` `--pagefind-ui-primary` | `var(--focus-ring)` |
+| `#docs-search-panel .pagefind-ui__result-nested .pagefind-ui__result-link:hover` | `color: var(--text)` |
+| `#docs-search-panel a:focus-visible` | `outline: 2px solid var(--focus-ring)` |
+| `#docs-search-panel mark`, `article.content-body mark.pagefind-highlight` | `background: var(--select-fill)` |
+| `.content-body a:not(…)` | see step 3 |
+| `.content-body blockquote` | `border-left: 3px solid var(--select-edge)`, `background: var(--select-fill)` |
+| `.highlight .nf, .highlight .nc` | `color: var(--code-keyword)` — it is a code token and belongs with the others, not with a retired accent |
+| `.content-body .docs-copy[data-copied]` | `color: var(--text)` |
+| `.docs-toc-item a[aria-current]` | `color: var(--text)` — the weight already changes, which was always the load-bearing half |
+| `.btn:focus-visible` | `outline: 2px solid var(--focus-ring)`, `border-color: var(--focus-ring)` |
+| `.btn-primary`, `.btn-primary:hover` | `background: var(--select-edge)`, `color: var(--bg)`; the `filter: brightness(1.08)` hover goes — see the note below |
+
+`.btn-primary:hover` on an ink fill cannot brighten its way to a visible change
+in both themes. Use `background: var(--text-muted)` instead, matching the
+application's `button-primary-hover`.
+
+- [ ] **Step 3: Links carry underline and weight, not hue**
+
+The documentation has no firewall state for colour to mean, so this is where the
+change is visible to a reader who never signs in:
+
+```css
+/* No hue: the documentation has no firewall state for colour to mean, so the
+   underline carries the affordance and the weight carries the emphasis. This is
+   the one place in 2.16 a reader who never signs in sees the change. */
+.content-body a:not(.btn):not(.docs-hero-brand):not(.feature-card) {
+  color: var(--link-ink);
+  font-weight: 500;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  transition: text-decoration-thickness 0.15s;
+}
+
+.content-body a:not(.btn):not(.docs-hero-brand):not(.feature-card):hover {
+  text-decoration-thickness: 2px;
+}
+```
+
+The `border-bottom: 1px solid transparent` the old rule used goes with it — an
+underline is what a link has.
+
+- [ ] **Step 4: `h1` takes the mono display voice**
+
+```css
+/* The same voice the application's page title takes: what is identified rather
+   than read. h2 and h3 inside an article stay Inter — a long-form page set in
+   mono headings throughout reads as a table. */
+.content-body h1 {
+  font-family: var(--font-mono);
+  font-size: 2rem;
+  font-weight: 300;
+  letter-spacing: -0.01em;
+  margin: 0 0 1.5rem;
+  color: var(--text);
+  line-height: 1.2;
+}
+```
+
+Leave `.content-body h2`, `h3` and `h4` untouched.
+
+- [ ] **Step 5: Rename the hero class in the markup**
+
+`docs/index.md:22`:
+
+```html
+    <span class="docs-hero-mark">No surprises.</span>
+```
+
+- [ ] **Step 6: Rebuild and grep**
+
+```bash
+npm run build:docs-css
+grep -c accent docs/assets/css/style.css                     # expected: 0
+grep -c '34,211,238\|8,145,178\|45,212,191' docs/assets/css/style.css   # expected: 0
+grep -o -- '--focus-ring:[^;]*' docs/assets/css/style.css    # expected: two
+go test ./internal/web/ -run 'TestNoAccentTokenSurvives|TestNoRetiredHueSurvives|TestDocsStylesheetKeepsLoadBearingRules|TestTheSearchOverridesAreOutsideTheCascadeLayer'
+```
+Expected: PASS, all four. Remove any `t.Skip` Task 3 left on the docs paths.
+
+- [ ] **Step 7: Verify by mutation**
+
+Put `--accent: #8fd3fb;` back into `:root`, rebuild, and
+`TestNoAccentTokenSurvives` goes red on both the source and the built file. Put
+`rgba(34,211,238,0.25)` back on `.sidebar-version` and `TestNoRetiredHueSurvives`
+goes red. Restore both.
+
+- [ ] **Step 8: Build the site and render it**
+
+```bash
+npm run build:docs
+npm run check:docs
+```
+
+Chrome extension against `docs/_site/docs/…` — **not the top-level `_site`
+paths, which are redirect stubs that bounce to production and silently review
+the live site.** Dark and light, 1600 / 900 / 390:
+
+- the landing page (`docs/_site/index.html`) — the hero tint is now a neutral
+  wash, which is intended and is the one place a signed-out reader sees 2.16
+- a long reference page (`configuration/`) — links read as links by underline
+  alone, and the `h1` in mono does not fight the Inter `h2`s under it
+- the search overlay — `mark` on `select-fill` rather than on a tinted accent
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/src/docs.css docs/assets/css/style.css docs/index.md internal/web/accent_guard_test.go
+git commit -m "feat(docs): the site follows — no hue, links underlined, h1 in the display voice
+
+A parallel replacement rather than the same patch twice: docs.css names its
+tokens differently and has four of them. Nine literal chromatic values a token
+rename walks straight past go with them — the retired Aurora cyan on three
+components and the teal in both hero glows. The application reserves colour for
+firewall state; the documentation has no state, and so has no colour."
+```
+
+---
+
+## Task 9: `DESIGN.md`
+
+The spec has been wrong three times, and the standing instruction is to amend it
+openly rather than deviate from it quietly. This task is where every decision
+above is written down.
+
+**Files:**
+- Modify: `DESIGN.md`
+
+**Interfaces:**
+- Consumes: every token, class and measurement from Tasks 3–8.
+- Produces: nothing executable.
+
+- [ ] **Step 1: Front matter**
+
+In the YAML block: replace the four `accent*` entries under `colors:` with the
+five new names and their dark values; add `primary: "#f1f3f6"` and
+`on-primary: "#0a0b0f"`. Under `typography:`, change `display` to
+`fontFamily: JetBrains Mono`, `fontSize: 34px`, `fontWeight: 300`,
+`letterSpacing: "-0.01em"`. Under `components:`, rewrite every entry that names
+`{colors.accent*}` — `button-primary`, `button-primary-hover`, `input-focus`,
+`chip-accent` (→ `chip-select`), `nav-item-active`, `avatar`, `toggle-on`,
+`checkbox-checked`, `link`, `module-active`.
+
+Update the `description:` paragraph: it currently describes the ice blue and the
+three situations it appears in. It now describes a system whose only hue is
+state.
+
+- [ ] **Step 2: Replace rule 1 and delete rule 2**
+
+In *Overview*:
+
+> **Colour means state.** `state-ok`, `state-warn` and `state-crit` are the
+> entire palette. Focus, selection and the primary action are carried by fill,
+> edge and weight. A screen with no colour on it is a screen with nothing to
+> report.
+
+Rule 2 (*the accent is rationed*) is deleted: there is no accent left to ration.
+Say that it was deleted and why, rather than silently renumbering — the file's
+own convention is to record amendments.
+
+- [ ] **Step 3: The colour tables**
+
+Replace the `accent*` rows in both *Dark* and *Light* with the five new tokens,
+and add the paragraph finding 3 requires:
+
+> **Four of these carry the same value as `ink`, and the fifth the same as
+> `surface-raised`.** That is not a duplication to tidy away. `action-fill`,
+> `select-edge` and `focus-ring` are three different questions — *what is the
+> one action here*, *which one is selected*, *where am I* — and a system that
+> answers them with one token cannot change one answer without changing the
+> other two. The names are roles; the values happen to agree today.
+
+And the measured pairs, because the numbers are the argument:
+
+| pair | Dark | Light |
+|---|---|---|
+| focus ring / `surface` | 16.72:1 | 18.88:1 |
+| action fill / `surface` | 16.72:1 | 18.88:1 |
+| *before 2.16:* accent fill / `surface` | 11.4:1 | 4.73:1 |
+| `select-fill` / `surface` | **1.08:1** | **1.08:1** |
+
+> The last row is why the accent could not simply be given a grey value. A fill
+> at 1.08:1 is the same invisibility as the focus ring this release replaced,
+> measured at 1.31:1. `select-edge` carries "this one is active";
+> `select-fill` only confirms it. **Any implementation that marks the active
+> element with a background alone is wrong**, and
+> `TestTheActiveNavItemCarriesAnEdgeAndNotOnlyAFill` is what says so.
+
+Answer the objection this file raises itself, about the eleven protection
+toggles: an on-toggle was accent-filled at 11.4:1 dark and **4.73:1 light**;
+ink-filled it is 16.72:1 and 18.88:1. The *on* state does not weaken when the
+colour goes — in light mode it becomes four times clearer.
+
+- [ ] **Step 4: The typography amendment**
+
+Replace the *Inter for language, JetBrains Mono for network data* rule:
+
+> **Inter for what is read. JetBrains Mono for what is identified.** Sentences,
+> descriptions, button labels and form labels are read. Ports, addresses,
+> counters, timestamps, the countdown and **the name of the page you are
+> standing on** are identified. Nothing between the two extremes of the scale is
+> mono.
+
+In *Scale*, `display` becomes `30–34 / 300, mono, -0.01em`. Record the ceiling
+and how it was reached: 19 unbreakable characters (`Systemeinstellungen`), 0.6 em
+advance, 11.4 em, roughly 358 px available at a 390 px viewport, 31.4 px.
+
+- [ ] **Step 5: Components**
+
+- *Buttons*: the primary action is `action-fill` with `action-ink`; hover is
+  `ink-muted` (8.1:1 dark, 5.8:1 light for the ink on it).
+- *Chips and tags*: `chip-accent` becomes `chip-select`; it marks a qualifier the
+  operator chose.
+- *Tables*: add the new rule —
+  > A data column is sized by its widest documented value, measured rendered
+  > rather than added up on paper. `.col-flex` absorbs the remainder.
+
+  and say that `.col-toggle` (94 px) and `.col-sources` (25 rem) were both reached
+  that way; the method was never written down, so each instance came back as a
+  defect.
+- *Forms*: the focus row of the five-state table becomes `focus-ring` border plus
+  a 2 px `focus-ring` outline at 2 px offset.
+- *Language and theme switches*: the select takes `appearance: none`, its own
+  chevron, and a `surface-raised` fill — this file already names the failure
+  (*"a field's `canvas` background sits 1.03–1.06:1 from the `surface` of the
+  card it is on"*), and on the login card the control was recognisable only by
+  its native arrow.
+- *Links and badges*: `link` is `ink` with a permanent underline. The old
+  reasoning (`accent-on-wash` because pale ice blue lacks contrast in light mode)
+  goes with the accent.
+- **New subsection, *Navigation*:** the group divider and indent, the first group
+  carrying none, and the active item's fill-plus-edge.
+- **New subsection, *The dashboard's two ranks*:** three tiles are ways into the
+  host, three change what the rules are; rank two is a list because three
+  numbers are not three states.
+- *Logo* → *Where the colour comes from*: the App chrome row's colour becomes
+  `ink`. Note that the baked raster favicon and the documentation copy stay
+  `#0f7bab` and are not re-rendered here.
+
+- [ ] **Step 6: The documentation site**
+
+State the reasoning so the two surfaces do not look like an accident: the
+application reserves colour for state; the documentation has no state, and so has
+no colour. Links there carry underline and weight; `h1` takes the mono display
+voice while `h2` and `h3` inside an article stay Inter, because a long-form page
+set in mono headings throughout reads as a table.
+
+- [ ] **Step 7: `Known Gaps`**
+
+- The baked favicon and the documentation's copy of the mark stay `#0f7bab`.
+  They already differed from the app chrome in dark mode; re-rendering the
+  raster set and the OG image was not in 2.16's scope.
+- *Charts* and *Density modes* stay as they are.
+- **Delete** *Light-mode accent distinctiveness* — there is no accent to be
+  distinct.
+
+- [ ] **Step 8: Check it**
+
+```bash
+npm run check:prose
+grep -c 'accent' DESIGN.md   # only in sentences describing what was removed
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add DESIGN.md
+git commit -m "docs(design): colour means state, and the display voice is mono
+
+Rule 1 replaced and rule 2 deleted — there is no accent left to ration. The
+typography rule is amended openly rather than deviated from: the name of the
+page you are standing on is identified, not read. Records that four of the five
+new tokens carry ink's value today and why the names are still separate."
+```
+
+---
+
+## Task 10: The record — screenshots, roadmap, carried-forward, changelog
+
+**Files:**
+- Modify: `docs/assets/img/screens/*` — all 36
+- Modify: `docs-tech/carried-forward.md`
+- Modify: `docs-tech/invariants.md`
+- Modify: `docs/_docs/roadmap.md`
+- Modify: `CHANGELOG.md`, `docs/_docs/changelog.md`, `debian/changelog`
+- Modify: `internal/shared/version.go`, `docs/_config.yml`
+
+**Interfaces:**
+- Consumes: the finished interface from Tasks 3–8.
+- Produces: the release.
+
+- [ ] **Step 1: Re-take all 36 screenshots**
+
+Every page carries the sidebar; none stays valid.
+
+```bash
+scripts/demo-server.sh &
+npm run check:ui -- --screenshots
+git status --short docs/assets/img/screens/   # expected: 36 modified
+```
+
+`takeFullScreenshotSet` covers the eleven authenticated paths plus login,
+enrolment, the wizard and the verify screen. If `two-factor-verify-*.png` reports
+`skip`, that is the known path and the run says why.
+
+- [ ] **Step 2: Look at them**
+
+A stale screenshot describes an interface that no longer exists, and a wrong one
+is worse than none. Open at least `dashboard-dark.png`, `dashboard-light.png`,
+`ports-dark.png`, `options-light.png` and `login-dark.png` and confirm: no ice
+blue anywhere, the sidebar's divider and indent are visible, the page title is
+mono, the dashboard has three tiles and a list.
+
+- [ ] **Step 3: Close the two carried-forward entries**
+
+In `docs-tech/carried-forward.md`, strike through both 2.15 table entries and
+close them with a date, the way the file's other closed entries are written:
+
+```markdown
+| ~~**`.col-port` is 120px and `8000:9000` needs 122px**~~ | **Closed 2026-09-??.** 128px. The decision `DESIGN.md` did not answer was already answered four declarations below, in `.col-toggle`'s own comment — `.col-flex` is `width: auto` and absorbs the remainder, so there was no zero-sum choice to make. The rule is now written down: a data column is sized by its widest documented value, measured rendered |
+| ~~**`.table-wrap` overflows horizontally by 10px in card mode**~~ | **Closed 2026-09-??.** A horizontal margin on a `width: 100%` block asks its container for room it does not have; the inset moved to the container's own padding. The check was strengthened first and separately — `checkContainersDoNotOverflow` measures every `overflow-x: auto` container, which the page-level check cannot see by construction, because a scrolling container absorbs its own overflow |
+```
+
+Also close the application-sidebar entry under *Design decisions nobody has made
+yet* — it is the entry this release exists to close.
+
+- [ ] **Step 4: Record the three guards in `invariants.md`**
+
+Add a section in the file's own shape: test name, what it protects, and the
+incident. `TestNoAccentTokenSurvives` / `TestNoRetiredHueSurvives`,
+`checkFocusIsVisible`, `checkContainersDoNotOverflow`,
+`TestTheSidebarGroupsCarryADividerAndAnIndent`,
+`TestTheActiveNavItemCarriesAnEdgeAndNotOnlyAFill`, and the version-chip pair.
+
+- [ ] **Step 5: The roadmap**
+
+Remove 2.16's row from the planned table and its line from the ASCII block, and
+change the front matter's `description:` from *Fourteen releases* to *Thirteen*.
+Nothing is inserted and nothing is reordered — 2.16 moves to *What already
+shipped*, which is the changelog link.
+
+**Note the inconsistency rather than fixing it here:** 2.14 and 2.15 are still
+listed in the planned table although both have shipped, so the count has been
+wrong since 2.14. Raise it in the pull request; tidying three rows is not this
+release's job.
+
+- [ ] **Step 6: Version and changelogs**
+
+Bump `shared.CurrentVersion` and `docs/_config.yml` to `2.16.0`, add the
+`debian/changelog` entry, write the `CHANGELOG.md` section, then:
+
+```bash
+npm run build:changelog && npm run check:changelog
+go test ./internal/shared/ -run 'TestThePackageVersionIsTheReleaseVersion|TestEveryChangelogVersionHasALinkDefinition|TestUnreleasedComparesAgainstTheNewestRelease'
+go test ./internal/web/ -run TestDocsVersionMatchesRelease
+```
+
+Add the `[2.16.0]` link definition and repoint `[unreleased]`.
+
+- [ ] **Step 7: The whole gate, once**
+
+```bash
+make test lint
+go test ./internal/...
+sudo go test -tags integration ./internal/core/...   # or the podman command in local-review.md
+npm run check:docs && npm run check:prose && npm run check:changelog && npm run check:diagrams
+npm run build:css && npm run build:docs-css && git diff --stat web/static docs/assets/css
+scripts/demo-server.sh & npm run check:ui
+```
+The `git diff --stat` after the rebuilds must be empty. A non-empty one means
+the committed output was stale.
+
+- [ ] **Step 8: Commit, PR, merge, tag**
+
+```bash
+git add -A
+git commit -m "2.16 — The interface looks like a firewall"
+gh pr create --base main --title "2.16 — The interface looks like a firewall"
+# CI green → merge → git tag -a v2.16.0 && git push origin v2.16.0
+```
+
+- [ ] **Step 9: Offer the Ko-fi post**
+
+A release going out is one of the two moments the standing instruction names.
+Ko-fi has no writing API — the post is made through the browser while signed in,
+and it cannot run in CI. Draft it and hand it over; do not attempt to publish it.
+
+---
+
+## Self-review
+
+**Spec coverage**
+
+| Spec section | Task |
+|---|---|
+| §0 the base is green first | Task 1 |
+| §1 what exists today, measured | Task 2 (the 1.31:1 the check must catch) |
+| §2 five tokens out, five in | Task 3 |
+| §3 the display voice, the removed line, the version chip | Task 4 |
+| §4 two ranks, `Manage →`, the promoted finding, `.tile-grid` | Task 5 |
+| §5 the sidebar, and the one native control | Task 6 |
+| §6 the 2 px and the 10 px | Tasks 7a, 7b |
+| §7 the documentation site | Task 8 |
+| §8 the three guards | Tasks 2, 3, 7a |
+| §9 documentation | Tasks 9, 10 |
+| §10 scope | the whole plan; the three *Out* items are untouched and stay in `carried-forward.md` |
+
+**Type consistency** — `ReleaseVersion` is named identically in
+`internal/shared/version.go`, `PageData`, `base.html` and the test.
+`.chip-select`, `.rule-list*`, `.stat-tile-finding` and `.docs-hero-mark` each
+appear in exactly the task that creates them and in the guard that checks them.
+`checkFocusIsVisible` and `checkContainersDoNotOverflow` are called from
+`runChecks` and `checkPageHealth` respectively, both named at their definitions.
+
+**Known open questions, both raised in the pull request rather than decided
+here:** the sidebar divider above *Rules* (finding 2), and the roadmap's stale
+2.14/2.15 rows (Task 10 step 5).

--- a/docs-tech/specs/2026-09-07-2.16-the-interface-looks-like-a-firewall.md
+++ b/docs-tech/specs/2026-09-07-2.16-the-interface-looks-like-a-firewall.md
@@ -1,0 +1,304 @@
+---
+title: "2.16 — The interface looks like a firewall"
+date: 2026-09-07
+status: approved, not yet planned
+---
+
+# 2.16 — The interface looks like a firewall
+
+Colour stops decorating and starts meaning something. After this release the only
+hue in the application is `state-ok`, `state-warn` and `state-crit` — a screen with
+no colour on it says the firewall has nothing to report. Everything the ice-blue
+accent used to mark (focus, active, the primary action) is carried by fill, edge
+and weight instead.
+
+Beside it, the two structural defects three design reviews deferred: the sidebar
+groups that never got the divider and indent the documentation sidebar was given,
+and six identical stat cards with `Manage →` appended to each. The page title
+takes a typographic position it has never had. And the two table defects
+`carried-forward.md` holds from 2.15 are closed here, where the tables are the
+subject rather than a passenger.
+
+Agreed with the maintainer on 2026-09-07: the full palette move rather than a
+cleanup, the accent removed rather than relocated, and the documentation site
+following the application rather than diverging from it.
+
+## 0 · The base this starts from
+
+**`main` is red before this branch exists, and it must be green before it is cut.**
+
+`check:ui`'s *language switch* is racy. `scripts/ui-check.mjs:830` waits with
+`waitForRequest`, which resolves when the request is *issued*; the
+`waitForLoadState('load')` after it then returns against the still-current, long
+since loaded document, and `ctx.cookies()` is read before `Set-Cookie` arrives.
+The comment at line 889 half-knows it already — *"this one was never racy the way
+the change handler above was."* The fix is `waitForResponse`.
+
+It lands as its own pull request **before** this branch is cut. A release that
+starts on a red base cannot prove anything is pre-existing, which is the exact
+mistake 2.15 made and `carried-forward.md` now opens by naming.
+
+## 1 · What exists today, measured
+
+Every number below was taken from the running demo, not read off the stylesheet.
+
+| | |
+|---|---|
+| Focus ring, keyboard-focused `.input`, dark | `outline: 2px solid rgba(143,211,251,0.13)` → composited **1.31:1** against its card |
+| The same control's border on focus | `#8fd3fb` → **11.4:1** — this is what actually carries focus on a text field |
+| `.toggle:focus-visible` (`app.css:1159`), `.checkbox:focus-visible` (`:1194`) | the 1.31:1 ring and **no border change** — read from the stylesheet, to be confirmed rendered |
+| Accent occurrences | 72 matching lines in `app.css`, 61 in `docs.css`; the tokens are duplicated by value, not shared |
+| Accent instances on one page (`/settings`) | **14**. `DESIGN.md`: *"A page with ice blue in five places has no accent at all."* |
+| `display` / `body` | 26 px / 600 against 13.5 px / 400 |
+| `countdown` | 40 px / 300 mono — the only typographic statement in the product, on one page |
+
+A focus indicator is covered by **WCAG 1.4.11 Non-text Contrast (AA)** at 3:1.
+2.4.13 *Focus Appearance* (3:1 plus a minimum area) is AAA; 2.4.11 is *Focus Not
+Obscured* and is not the relevant criterion.
+
+## 2 · Colour — five tokens out, five in
+
+One for one, so the diff stays legible.
+
+| removed | added | Dark | Light | Role |
+|---|---|---|---|---|
+| `--color-accent` | `--color-action-fill` | `#f1f3f6` | `#0f1116` | fill of the one primary action on a page |
+| `--color-accent-ink` | `--color-action-ink` | `#0a0b0f` | `#ffffff` | text and icons on it |
+| `--accent-wash` | `--color-select-fill` | `#181b22` | `#f4f6f9` | surface of the active element |
+| `--color-accent-on-wash` | `--color-select-edge` | `#f1f3f6` | `#0f1116` | the 2 px edge on it |
+| `--color-accent-hover` | `--color-focus-ring` | `#f1f3f6` | `#0f1116` | 2 px, with `outline-offset: 2px` |
+
+Computed against the surfaces they sit on:
+
+| pair | Dark | Light |
+|---|---|---|
+| focus ring / `surface` | 16.72:1 | 18.88:1 |
+| action fill / `surface` | 16.72:1 | 18.88:1 |
+| *today:* accent fill / `surface` | 11.4:1 | 4.73:1 |
+| **`select-fill` / `surface`** | **1.08:1** | **1.08:1** |
+
+**The last row is why the accent could not simply be given a grey value.** A fill
+at 1.08:1 is the same invisibility as today's focus ring. `select-edge` carries
+"this one is active"; `select-fill` only confirms it. Any implementation that
+marks the active nav item with a background alone is wrong, and the guard in §8
+is what says so.
+
+The objection this must answer, because `DESIGN.md` raises it itself: the options
+page carries eleven protection toggles and *"a page where only the enabled toggles
+are visible is worse than no page at all."* Today an on-toggle is accent-filled at
+11.4:1 dark and **4.73:1 light**. Ink-filled it is 16.72:1 and 18.88:1. The *on*
+state does not weaken when the colour goes; in light mode it becomes four times
+clearer.
+
+`state-ok`, `state-warn`, `state-crit` and their six `-on-wash` variants are
+untouched. After this release they are the only chromatic values in the
+application.
+
+Rule 1 in `DESIGN.md`'s overview — *"Colour outside the blue family means state"* —
+is replaced, not amended:
+
+> **Colour means state.** `state-ok`, `state-warn` and `state-crit` are the entire
+> palette. Focus, selection and the primary action are carried by fill, edge and
+> weight. A screen with no colour on it is a screen with nothing to report.
+
+Rule 2 (*the accent is rationed*) is deleted: there is no accent left to ration.
+
+## 3 · Typography — the display voice
+
+`display` becomes **JetBrains Mono 300**, tracking `-0.01em`:
+
+| viewport | size |
+|---|---|
+| `< 900px` | 30 px |
+| `>= 900px` | 34 px |
+
+30 is a ceiling, not a preference. The longest page title across all three locales
+is 23 characters (`Changer le mot de passe`, fr) and wraps at its spaces; the
+longest **unbreakable** string is 19 characters — `Systemeinstellungen`, a German
+compound with no break point. JetBrains Mono advances 0.6 em, so 19 characters is
+11.4 em; at a 390 px viewport roughly 358 px is available inside the padding,
+which puts the ceiling at 31.4 px. Verify this by rendering `/settings` in German
+at 390 px, not by trusting the arithmetic.
+
+This contradicts a rule in `DESIGN.md` — *Inter for language, JetBrains Mono for
+network data* — and the rule is amended openly rather than quietly deviated from:
+
+> **Inter for what is read. JetBrains Mono for what is identified.** Sentences,
+> descriptions, button labels and form labels are read. Ports, addresses, counters,
+> timestamps, the countdown and **the name of the page you are standing on** are
+> identified. Nothing between the two extremes of the scale is mono.
+
+The countdown already proved the voice works; it appeared on one page.
+
+Two things travel with it:
+
+- **The `Running version …` line above the dashboard `h1` is removed.** It repeats
+  the topbar chip a few centimetres above it, and a label above a heading is the
+  commonest generated-page tell. `dashboard_running` leaves all three locales.
+- **The topbar version chip stops truncating.** It renders `v2.14.0-44-g5…` today
+  and reads as broken data. The chip shows the **release version only** —
+  `v2.15.0` — and the full `git describe` string moves to its `title` attribute,
+  where a development build is still recoverable without the chrome carrying an
+  ellipsis. The existing check *the version badge fits every version string a
+  build can carry* must still pass against the shortened form.
+
+## 4 · Dashboard — two ranks, not one grid
+
+The six tiles are not six of the same thing. Three are ways into the host; three
+change what the rules are. One grid claims otherwise.
+
+```
+Rule sets   Counts are from the rules currently loaded
+
+┌──────────────────────┐ ┌──────────────────────┐ ┌──────────────────────┐
+│ TCP ports            │ │ UDP ports            │ │ Port forwarding      │
+│  8                   │ │  3                   │ │  4                   │
+│  accepting           │ │  accepting datagrams │ │  NAT redirects       │
+│  connections         │ │                      │ │                      │
+│  ── 1 unused for     │ │                      │ │                      │
+│     30+ days         │ │                      │ │                      │
+└──────────────────────┘ └──────────────────────┘ └──────────────────────┘
+
+  Blacklisted IPs    5   dropped before any rule
+  Whitelisted IPs    5   bypass every port rule
+  Custom rules       3   raw nftables statements
+```
+
+Rank two is a list, not a card: no border, no radius, no icon. Three numbers are
+not three states.
+
+- **`Manage →` goes, six times.** The tile is already an `<a>` (`a.stat-tile`); an
+  arrow announcing that a link is a link is decoration. `tile_manage` leaves all
+  three locales, and `.stat-tile-cta` leaves the stylesheet.
+- **The unused-port finding is promoted.** `tile_tcp_unused` sits in the tile's
+  smallest type today. It gets its own line under a hairline. It is the most useful
+  sentence on the page and the reason 2.15 happened.
+- **`.tile-grid`'s orphan problem dissolves.** The comment at `minmax(168px, 1fr)`
+  worries about one stray tile per row; with three tiles in rank one there is no row
+  to strand.
+
+## 5 · Sidebar, and the one native control
+
+The device the documentation sidebar already has, for the reason `DESIGN.md`
+already gives — label and link sit twelve steps apart per channel, which is
+distinct on paper and the same grey once rendered. With no accent left, colour
+carries even less.
+
+```
+   Dashboard                    ungrouped, no rule above it
+─────────────────────────
+   RULES                        label: 10px mono, +0.1em, unchanged
+     Ports                      indented: container, then contents
+   ▏ Blacklist                  active: select-fill + 2px select-edge
+     Whitelist
+     …
+─────────────────────────
+   SYSTEM
+     …
+```
+
+The first group carries no `border-top`: it follows *Dashboard*, not another
+group, and a rule there would divide nothing.
+
+**The language `<select>` gets `appearance: none` and its own chevron.** It is the
+only native control in the interface, and its fill moves from `canvas` to
+`surface-raised` — `DESIGN.md` describes the failure itself: *"a field's `canvas`
+background sits 1.03–1.06:1 from the `surface` of the card it is on."* On the login
+card the control is currently recognisable only by its native arrow.
+
+## 6 · Tables — the 2 px and the 10 px
+
+**`.col-port` is 120 px and `8000:9000` needs 122.** `carried-forward.md` says the
+fix needs a decision `DESIGN.md` does not answer. It is already answered four
+declarations below, in `.col-toggle`'s own comment: *"Every pixel given back goes
+to `.col-flex`."* `.col-flex` is `width: auto` and absorbs the remainder, so there
+is no zero-sum choice to make. What is missing is the rule, and it goes into
+`DESIGN.md`:
+
+> A data column is sized by its widest documented value, measured rendered rather
+> than added up on paper. `.col-flex` absorbs the remainder.
+
+`.col-toggle` (94 px) and `.col-sources` (25 rem) were both reached that way. The
+method was never written down, so each instance came back as a defect.
+
+**`.table-wrap` overflows by 10 px in card mode, and `check:ui` does not fire on
+it.** `carried-forward.md` warns that a fix which only silences the symptom leaves
+the check blind. Two steps, in this order and not merged:
+
+1. Establish **why** the overflow check misses it. The deliverable is a stronger
+   check, not a fix. If it turns out the check measures the page and not the
+   containers inside it, that is a class of blind spot rather than one instance.
+2. Then remove the 10 px. The strengthened check must be red before the fix and
+   green after.
+
+## 7 · The documentation site
+
+`docs.css` follows across its 61 matching lines. Its tokens are **named
+differently and there are four of them**, not five — `--accent`, `--accent-on`,
+`--accent-dim`, `--accent-hover` — so this is a parallel replacement, not the same
+patch applied twice:
+
+| removed | added | Role |
+|---|---|---|
+| `--accent` | `--focus-ring` | focus outline, 2 px |
+| `--accent-on` | `--link-ink` | link text — `ink`, with the underline carrying the affordance |
+| `--accent-dim` | `--select-fill` | active sidebar item, hero wash |
+| `--accent-hover` | `--select-edge` | the edge on it |
+
+`h1` takes the mono display voice, and — because the documentation has no firewall
+state for colour to mean — **links carry underline and weight instead of hue.**
+
+The landing hero's tint goes with it. `docs.css:608` paints it with
+`radial-gradient(… var(--accent-dim) …)`, whose own comment says it is *"made of
+tinted accents only"*; under `--select-fill` it becomes a neutral wash. That is
+intended, and it is the one place where the change is visible to a reader who
+never signs in.
+
+`h2` and `h3` inside an article stay Inter. A long-form page set in mono headings
+throughout reads as a table.
+
+`DESIGN.md` states the reasoning so the two surfaces do not look like an accident:
+the application reserves colour for state; the documentation has no state, and
+so has no colour.
+
+## 8 · The proof this release owes
+
+Without these it is a repaint.
+
+| Guard | What it catches |
+|---|---|
+| **No `accent` token survives.** A grep guard over both stylesheets, in the style of the existing invariants | the colour returning in six months "just for this one case" |
+| **Focus visibility in `check:ui`.** Tab through every focusable element on all 13 pages, composite the indicator against its actual backdrop, require **>= 3:1** | the defect measured in §1 at 1.31:1, and every future one. It asserts a value, not an appearance |
+| **Per-container table overflow**, not per page | the class the 10 px belongs to |
+
+The focus check runs at **one width in both themes** — focus colour does not vary
+with viewport — so it costs roughly 26 extra page passes, not 130.
+
+Each guard is verified by mutation, not by reading: revert the token, weaken the
+ring, restore the 10 px, and watch each one go red.
+
+## 9 · Documentation
+
+| | |
+|---|---|
+| **All 36 screenshots** in `docs/assets/img/screens/` | every page carries the sidebar; none stays valid |
+| `DESIGN.md` | colour tables, the two replaced rules, the typography amendment and scale, components (nav, tiles, select, focus), the new column rule, `Known Gaps` |
+| `docs/_docs/roadmap.md` | 2.16 moves to *What already shipped* via the changelog; no reordering, nothing is inserted |
+| `carried-forward.md` | the two 2.15 table entries struck through and closed with a date |
+| `locales/*.json` | `tile_manage` and `dashboard_running` removed from `en`, `de`, `fr`. No new strings; `en`/`de` parity holds by construction |
+
+## 10 · Scope
+
+**In:** the five-token replacement in both stylesheets; the display voice; the
+dashboard's two ranks; the sidebar divider, indent and active treatment; the
+language select; the two table defects; three guards; 36 screenshots; `DESIGN.md`.
+
+**Out, and why:**
+
+- **The flaky `language switch`** — lands before the branch, as its own pull
+  request. Inside it, the branch could not prove what predates it.
+- **The `codespell` scope gap and the nine unstyled rouge token classes** — real,
+  found, and unrelated to this theme. They stay in `carried-forward.md`.
+- **`security.md` overflowing at 390 px** — a documentation-site defect whose fix
+  (`overflow-wrap` on `.content-body code`) would break every long identifier on
+  the site. It needs a decision of its own and does not get one here.


### PR DESCRIPTION
The record of how 2.16 was planned, kept because the release itself is already merged and this is the half that explains why it looks the way it does. `docs-tech/` only — never published.

## What is in it

| | |
|---|---|
| `specs/…2.16….md` | the approved spec, unchanged since it was written |
| `plans/…2.16…-implementation.md` | ten tasks, with the dependency graph, the file structure and a mutation step on every guard |

## Why it is worth keeping rather than deleting

The plan was corrected three times while it was being executed, and each correction is the interesting part:

- **Ten findings the spec does not settle** are listed up front, because each changes what a task does. `dashboard_running` had two call sites, not one. `.chip-accent` was live markup. Four of the five new tokens carry `ink`'s value, which needed saying or the next reader deletes them as duplicates. `--color-accent-hover` had no successor for the job it actually did.
- **Every contrast figure the spec states was recomputed** before the plan quoted it. All six reproduce exactly.
- **A finding I wrote into the plan was wrong, and the correction is in the history.** I recorded that three controls had no focus indicator at all, at 1.02:1, and called it WCAG 2.4.7 Level A. It was a measurement artefact — those controls carry Chrome's own `outline: auto`, which is painted as a high-contrast ring and reported as a colour it does not paint. The real defect is narrower and cleaner: 66 controls per theme, all of one shape.
- **The three ways to measure focus wrongly** are written into Task 2, because all three were hit building the check.

The spec's §5 diagram and its prose disagree about whether the first sidebar group carries a divider. The plan follows the prose and says so; the shipped code does too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)