### PR TITLE
release: 2.17.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,40 @@
+easywall (2.17.0) unstable; urgency=medium
+
+  * Fix: all three conntrack masks are native-endian. For five releases the
+    established/related accept, the invalid-packet drop and the SSH
+    brute-force meter matched no packet while every surface reported them
+    enabled. `nft list ruleset` renders byte order invisibly, which is why
+    reading the rules found nothing.
+  * Fix: the established-accept rule carried no counter and no id comment, so
+    `RuleCounters` skipped it. It now carries both under the reserved id
+    `_established` — the one counter that catches this defect class again.
+  * Fix: a finding named the wrong rule. `Finding.Index` was a plain zero for
+    both per-chain checks, so a jump at input rule 3 was audited as
+    "input rule 0".
+  * Feat: `easywall-core health` — three lines and an exit code, 0 ok,
+    1 degraded, 2 fail, with seven reasons because a state with no cause is
+    not actionable at three in the morning.
+  * Feat: `GET /healthz` on the web process, the one route that answers
+    without a session. Loopback only until an operator widens it, matched
+    against the TCP peer and never a forwarding header.
+  * Feat: every nftables expression is checked before it reaches netlink — a
+    byte-reversed mask, an undefined bit, a jump to a chain nobody creates.
+    Findings surface as degraded; the check never refuses to write.
+  * Feat: four behavioural claims proven with real packets over a veth pair in
+    a throwaway network namespace, built with netlink alone.
+    `easywall-selftest.service` runs it once per version and kernel, and is
+    the only place CAP_SYS_ADMIN appears in this repository.
+  * Feat: the image gets its first HEALTHCHECK, a year after the compose file
+    got one. A plain `docker run` was checked by nothing at all.
+  * Feat: `Type=notify` and `WatchdogSec=60s` on easywall-core.service.
+    Under `Type=simple` the unit was active the instant exec returned, before
+    the socket the web unit waits for existed.
+  * Fix: `supervisorctl` works inside the image. It answered ".ini file does
+    not include supervisorctl section" and exited 2, so every documented way
+    of stopping one of the two processes printed an error and did nothing.
+
+ -- JP <12394156+jp1337@users.noreply.github.com>  Wed, 09 Sep 2026 23:28:51 +0200
+
 easywall (2.16.0) unstable; urgency=medium
 
   * Feat: colour stops decorating and starts meaning something. The ice-blue

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,7 +16,7 @@ timezone: Europe/Berlin
 # Shown as the badge in the sidebar. Must match shared.CurrentVersion in
 # internal/shared/version.go — TestDocsVersionMatchesRelease enforces that.
 # It was hardcoded in the layout as "v2.4" and drifted a patch release behind.
-version: "2.16.0"
+version: "2.17.0"
 
 tagline: "Your firewall. Your rules. No surprises."
 logo: /assets/img/icon.svg

--- a/internal/shared/version.go
+++ b/internal/shared/version.go
@@ -27,7 +27,7 @@ import (
 // stylesheet URL never changed across an upgrade even though it is versioned
 // precisely so that it does. `easywall-core --version` prints this, so a build
 // can be checked rather than assumed.
-var CurrentVersion = "2.16.0"
+var CurrentVersion = "2.17.0"
 
 const (
 	// cacheMaxAge is how long a successful check is trusted.


### PR DESCRIPTION
The version bump for the tag. Three files, no code.

| File | Why it is in here |
|---|---|
| `internal/shared/version.go` | what the binary reports, and what `-ldflags -X` overrides at build time |
| `docs/_config.yml` | the documentation sidebar badge reads it |
| `debian/changelog` | `debian/rules` takes the package version from it — it sat at 2.0.0 for five releases |

Two guards pin them to each other: `TestThePackageVersionIsTheReleaseVersion`
and `TestDocsVersionMatchesRelease`. Moving one alone is a red suite, which is
the point.

`CHANGELOG.md` and `docs/_docs/changelog.md` already carry the 2.17.0 section —
#170 wrote them. This is only what belongs to the tag.

Its own pull request because a direct push to `main` is refused, owner
included: a brand-new commit has no passing checks. `docs-tech/ci-and-release.md`
step 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
