### PR TITLE
2.18 follow-up: the mutations that stayed green

### DIFF
--- a/docs-tech/carried-forward.md
+++ b/docs-tech/carried-forward.md
@@ -50,6 +50,30 @@ source. See `TestTheTechnicalDocsAreNotPublished`.
 Found while making a second factor mandatory. Nothing here is a defect the
 release caused — those were fixed in it.
 
+## The mutations that stayed green
+
+A 75-mutation audit of this release's guards: 56 red, 19 green. No shipping
+defect — every green one is a place where the code can be broken without a test
+noticing. Six were closed before the release; the rest are here with their
+measurement, which is the part that saves the next person the work.
+
+| | |
+|---|---|
+| **The ACME serving path has no unit coverage at all** | `tlscert.go`. `GetCertificate` can stop consulting the autocert manager and fall through to the self-signed path, and `m.sslDir = ""` can be deleted — which makes easywall generate and periodically renew a self-signed certificate *alongside* the ACME one — with the whole suite green. Only `acme_integration_test.go` catches either, and that file is behind `//go:build integration` and a `CLONE_NEWNET` `TestMain`, so without `CAP_SYS_ADMIN` it exits 1 with **no message at all** (`FAIL … 0.004s`). Closing it: build a `certManager` with ACME on and assert `m.acme != nil && m.sslDir == ""`, and that a `hello` for the wrong SNI returns autocert's host-policy error rather than a self-signed certificate |
+| **No end-to-end passkey ceremony ever runs with a port in the origin** | `newPasskeyTestServer` pins `BindAddr = "127.0.0.1:443"`, and its comment says why: that is how an ordinary HTTPS installation reads. easywall's own default is `:12227`. `TestPublicOriginCarriesTheListeningPort` now holds the string, and `webAuthn()` passes `publicOrigin()` straight into `RPOrigins`, so the gap is narrow — but a ceremony that disagreed with it would still not fail here. Closing it: a `withBindAddr(":12227")` option on the shared fixture, used by one ceremony test |
+| **`TestTheRuleIsStatedOnce` catches the identifier, not the rule** | A second copy of the password floor written `len(pw) < 12` passes; written `len(pw) < minPasswordLen` it fails. The guard greps for the constant's name, so the one way of restating the rule that a careless author would actually use is the way it cannot see |
+| **`passkeys.json`'s file mode is unpinned** | `0600` → `0644` is silent. The file holds credential IDs and public keys, not secrets, which is why this is low — but this repository pins modes elsewhere, and an operator reading `ls -l` for reassurance gets it from the mode |
+| **The `v3:` domain separator is not pinned** | Reverting `credentialFingerprint` to `v2:` is invisible. The added passkey input already changes the digest, so the bump is belt-and-braces — and the same claim was made for v1 → v2 in 2.8 and guarded then either |
+| **`Prompt` could return false**, and **`newACMEManager`'s hostname re-check is unguarded** | `acme.go`. Both would fail every issuance; both are caught only by the integration test above, which is the one that cannot run locally. The config-level twins (`TestACMEIsRefusedWithoutAgreedTerms`, `TestACMENeedsAHostname`) do hold their half |
+| **`JustGated` is unobservable when no codes are minted** | `password.html` nests `{{if .JustGated}}` inside `{{if .Codes}}`, so a test can only see the flag through the codes block. A future change that set it without minting would be invisible to any HTTP-level test |
+
+Four more mutations were green and **behaviourally inert** — the mutation cannot
+change what the program does. Recorded so nobody re-runs them: the corrupt-store
+early return (a failed `json.Unmarshal` leaves the zero value anyway), the
+port-80 state computed without ACME (the template's own `{{if .ACMEEnabled}}` is
+the real guard, proven by its own red mutation), and the two renewal-loop
+short-circuits, which both hinge on `m.sslDir == ""`.
+
 ## Found in `invariants.md` itself, and older than this branch
 
 Noticed while adding this release's guards. Both are proven against `fbac69f`;

--- a/internal/web/handler_2fa_test.go
+++ b/internal/web/handler_2fa_test.go
@@ -151,6 +151,49 @@ func TestEnrol_ConfirmDoesNotReMintCodesWhenItIsNotTheFirstFactor(t *testing.T) 
 	}
 }
 
+// TestEnrol_ConfirmMintsNothingForASecondFactorWithNoCodesStored separates the
+// two halves of `wasFirstFactor && len(hashes) == 0`.
+//
+// The sibling above sets both a passkey and a stored set of codes, so
+// len(hashes) == 0 is false on its own and carries the whole assertion:
+// wasFirstFactor := true leaves it green. Here a passkey is enrolled and
+// nothing is stored, so only wasFirstFactor can hold the branch shut — and
+// with it JustGated, which decides whether this response also offers a way
+// past a gate the operator never came through.
+func TestEnrol_ConfirmMintsNothingForASecondFactorWithNoCodesStored(t *testing.T) {
+	s := serverWithPassword(t)
+	if err := s.passkeys.add("already enrolled", webauthn.Credential{ID: []byte("existing-cred")}); err != nil {
+		t.Fatal(err)
+	}
+	if n := len(s.cfg.RecoveryCodes()); n != 0 {
+		t.Fatalf("%d recovery codes stored before the fixture starts; this test needs none", n)
+	}
+
+	_, cookie := beginEnrolment(t, s)
+	secret := s.pendingSecretFor(t, cookie)
+	raw, _ := decodeTOTPSecret(secret)
+
+	rec := doFormRequest(s, "POST", "/password/2fa/confirm", "code="+totpAt(raw, stepAt(time.Now())), cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("confirm answered %d, want 200", rec.Code)
+	}
+	if !s.cfg.TOTPEnabled() {
+		t.Fatal("a correct code did not enable the factor")
+	}
+	if got := s.cfg.RecoveryCodes(); len(got) != 0 {
+		t.Errorf("%d recovery codes were minted for a second factor: %v — the passkey already satisfied the mandate, "+
+			"and a printout the operator may hold must not be invalidated by pairing TOTP beside it", len(got), got)
+	}
+	// JustGated is only observable through the one element it adds: the link
+	// onward, inside the block that shows the codes. No codes, no block — so
+	// the assertion is that neither is here. A wasFirstFactor that is wrongly
+	// true mints the codes, which renders both.
+	if body := rec.Body.String(); strings.Contains(body, "recovery-code") || strings.Contains(body, "&rarr;") {
+		t.Error("the codes block or its JustGated link was rendered; nothing was minted and the operator " +
+			"did not arrive through the gate")
+	}
+}
+
 // The clock is the largest support risk and no security risk. A code that is
 // right but far out gets a diagnosis with a sign and a magnitude, and nothing is
 // stored.

--- a/internal/web/handler_firstrun_test.go
+++ b/internal/web/handler_firstrun_test.go
@@ -444,3 +444,41 @@ func TestSaveFirstRun_SecondSetupCannotTakeOverTheAccount(t *testing.T) {
 		t.Errorf("the account changed hands: %q became %q", user, after)
 	}
 }
+
+// TestPublicOriginCarriesTheListeningPort.
+//
+// publicOrigin is the WebAuthn RPOrigins value, and a browser compares it
+// against the origin it actually loaded — so an origin missing the port makes
+// every ceremony fail with a mismatch no Go test would ever see. Untested
+// before this: every passkey fixture pins BindAddr to :443 on purpose, which
+// is the one configuration where the port branch is dead, while easywall's own
+// default bind is :12227. Deleting the branch left the whole suite green.
+//
+// The malformed row is what webPort does, not a guess: net.SplitHostPort
+// errors on an address with no colon, webPort logs and returns "", and the
+// origin then carries no port — the same shape as :443, which is the right
+// failure mode for an origin that cannot be computed.
+func TestPublicOriginCarriesTheListeningPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		bindAddr string
+		want     string
+	}{
+		{"the https default is left off", "127.0.0.1:443", "https://firewall.example.org"},
+		{"easywall's own default port is named", ":12227", "https://firewall.example.org:12227"},
+		{"a non-default port on an interface", "127.0.0.1:8443", "https://firewall.example.org:8443"},
+		{"IPv6 brackets are not mistaken for the port", "[::]:12227", "https://firewall.example.org:12227"},
+		{"an address with no port at all", "127.0.0.1", "https://firewall.example.org"},
+		{"an unparsable address", "not-an-address", "https://firewall.example.org"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{cfg: &Config{}}
+			s.cfg.TLS.Hostname = "firewall.example.org"
+			s.cfg.BindAddr = tc.bindAddr
+			if got := s.publicOrigin(); got != tc.want {
+				t.Errorf("publicOrigin() with bind_addr %q = %q, want %q", tc.bindAddr, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/web/handler_passkey_test.go
+++ b/internal/web/handler_passkey_test.go
@@ -513,6 +513,42 @@ func TestPasskeyFinishRefusesAnOverLongName(t *testing.T) {
 	}
 }
 
+// TestPasskeyFinishAcceptsANameAtTheBound is the other side of the same
+// comparison, and the one that makes the rune count observable at all.
+//
+// TestPasskeyFinishRefusesAnOverLongName's fixture is 65 runes *and* 130
+// bytes, so a byte-counting implementation rejects it for the wrong reason and
+// stays green; nothing there distinguishes `>` from `>=` either. Exactly
+// maxPasskeyNameLen runes of a two-byte character is 64 characters and 128
+// bytes — the largest name the rule allows, and one len() calls twice too
+// long. It must be stored, under that exact name: a bound that rejects here
+// costs the operator the naming they were told to use, and one counting bytes
+// halves the limit for anybody not writing ASCII.
+//
+// Modelled on passwordPolicyError's umlaut cases, which catch their own
+// byte/rune mutation the same way.
+func TestPasskeyFinishAcceptsANameAtTheBound(t *testing.T) {
+	s := newPasskeyTestServer(t, withHostname("firewall.example.org"))
+
+	name := strings.Repeat("\u00e9", maxPasskeyNameLen)
+	if utf8.RuneCountInString(name) != maxPasskeyNameLen || len(name) != 2*maxPasskeyNameLen {
+		t.Fatalf("the fixture is %d runes in %d bytes, want %d runes in %d bytes — "+
+			"it cannot tell a rune count from a byte count otherwise",
+			utf8.RuneCountInString(name), len(name), maxPasskeyNameLen, 2*maxPasskeyNameLen)
+	}
+
+	enrolPasskey(t, s, name)
+
+	stored := s.passkeys.all()
+	if len(stored) != 1 {
+		t.Fatalf("%d passkeys stored, want 1 — a name of exactly %d runes was refused",
+			len(stored), maxPasskeyNameLen)
+	}
+	if stored[0].Name != name {
+		t.Errorf("stored name = %q, want the %d-rune name that was submitted", stored[0].Name, maxPasskeyNameLen)
+	}
+}
+
 // TestEnrollingAPasskeyMintsRecoveryCodesWhenItIsTheFirstFactor.
 //
 // Recovery codes were minted only on the TOTP path, because that was the only
@@ -574,6 +610,48 @@ func TestRemovingAPasskeyEndsSessions(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != 303 {
 		t.Error("a session open before the passkey was removed still works")
+	}
+}
+
+// TestRemovingAPasskeyReStampsTheActingSession is the counterpart
+// TestEnrollingReStampsTheActingSession had on the enrolment side and removal
+// did not.
+//
+// Removal changes the fingerprint just as enrolment does, so without the
+// re-stamp the operator who pressed Remove is signed out by their own click —
+// and TestRemovingAPasskeyEndsSessions cannot see it: it only ever checks the
+// *other* session, which is supposed to die. Deleting restampSession from
+// handlePasskeyRemove left the whole suite green.
+//
+// The cookie is re-read from the response the way enrolPasskeyWithCookie does
+// it, because that is what a browser's cookie jar does: the session lives in
+// the cookie's own value, so a re-stamp is only observable by carrying the new
+// one forward.
+func TestRemovingAPasskeyReStampsTheActingSession(t *testing.T) {
+	s := newPasskeyTestServer(t, withHostname("firewall.example.org"),
+		withTOTP("JBSWY3DPEHPK3PXP")) // a second factor, so removal is allowed at all
+	acting := s.signIn(t)
+	id := enrolPasskeyWithCookie(t, s, "the lost one", acting)
+
+	remove := doFormRequest(s, "POST", "/password/passkey/remove", url.Values{
+		"id":               {base64.RawURLEncoding.EncodeToString(id)},
+		"current_password": {testPassword},
+	}.Encode(), acting).Result()
+	remove.Body.Close()
+	if remove.StatusCode != http.StatusSeeOther {
+		t.Fatalf("remove answered %d, want %d", remove.StatusCode, http.StatusSeeOther)
+	}
+	for _, c := range remove.Cookies() {
+		if c.Name == SessionName {
+			acting.Value = c.Value
+		}
+	}
+
+	resp := s.getWithCookie(t, "/dashboard", acting)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("the session that removed the passkey answered %d on /dashboard, want 200 — "+
+			"the operator was signed out by their own click", resp.StatusCode)
 	}
 }
 

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -115,7 +115,18 @@ func RequireAuth(store sessions.Store, currentCredential func() string) func(htt
 func RequireSecondFactor(hasFactor func() bool, isDemo func() bool) func(http.Handler) http.Handler {
 	// The routes enrolment itself needs. Exact matches, not a prefix: a prefix
 	// of "/password" would also admit anything a later release mounts below it,
-	// and the gate would widen without anyone deciding that it should.
+	// and the gate would widen without anyone deciding that it should. Nothing
+	// the router registers today tells the two apart, so
+	// TestTheGateAllowlistIsExactAndNotAPrefix drives this middleware directly
+	// and asks about paths no route has — without it, the sentence above is a
+	// description of a guarantee nothing holds.
+	//
+	// "/logout" is the one entry the router does not exercise: server.go
+	// registers POST /logout in the public group, which RequireSecondFactor is
+	// not mounted on, so the gate never meets it and this entry is inert today.
+	// It stays because a way out must never need the factor it is gating, and
+	// the day /logout moves inside the authenticated group is not the day to
+	// rediscover that. Same test holds it.
 	allowed := map[string]bool{
 		"/password":                      true,
 		"/password/2fa/begin":            true,

--- a/internal/web/middleware_test.go
+++ b/internal/web/middleware_test.go
@@ -611,9 +611,13 @@ func TestTheGateCannotBeWalkedPast(t *testing.T) {
 	// (including the bare "/", whose entire handler is
 	// a redirect to the gated /dashboard, and which the gate intercepts
 	// before that handler ever runs), plus POST /logout, which isGatedRoute
-	// does not exclude (it sits in the public group but is listed in
-	// `allowed` above, on purpose — a way out must never need the factor it
-	// is gating). A floor copied from the plan (15) would have passed while
+	// does not exclude. /logout is listed in `allowed` above only so this
+	// walk does not demand a gate header from it: server.go registers it in
+	// the public group, so RequireSecondFactor never runs on it and it can
+	// answer no other way. Nothing here proves the middleware's own
+	// "/logout" entry does anything — that is
+	// TestTheGateAllowlistIsExactAndNotAPrefix's job, which calls the
+	// middleware directly. A floor copied from the plan (15) would have passed while
 	// missing most of the actual group; a floor above the real count would
 	// fail on every run for no reason.
 	if checked < 41 {
@@ -654,6 +658,73 @@ func TestTheGateOpensAsSoonAsAFactorExists(t *testing.T) {
 			defer resp.Body.Close()
 			if resp.StatusCode != 200 {
 				t.Errorf("/dashboard answered %d with %s enrolled", resp.StatusCode, tc.name)
+			}
+		})
+	}
+}
+
+// TestTheGateAllowlistIsExactAndNotAPrefix drives RequireSecondFactor directly,
+// over a handler of this test's own, instead of through the router.
+//
+// Through the router the map's entries are only as load-bearing as the routes
+// that happen to be registered, and two of them were not load-bearing at all:
+// no route today distinguishes an exact match from a prefix one, so widening
+// allowed[r.URL.Path] to strings.HasPrefix left the whole suite green; and
+// "/logout" sits in server.go's public group, so the middleware never sees it
+// and deleting that entry changed nothing either. Here the middleware is the
+// whole subject — every entry is asserted on its own terms, and a path no
+// route registers can be asked about.
+func TestTheGateAllowlistIsExactAndNotAPrefix(t *testing.T) {
+	no := func() bool { return false }
+	gate := RequireSecondFactor(no, no)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	}))
+
+	for _, tc := range []struct {
+		path  string
+		gated bool
+	}{
+		// Enrolment needs every one of these, and /logout is here for the
+		// reason the map lists it: whatever group a way out is registered in
+		// today, it must never need the factor it is gating.
+		{"/password", false},
+		{"/password/2fa/begin", false},
+		{"/password/2fa/confirm", false},
+		{"/password/2fa/enrol-unverified", false},
+		{"/password/2fa/disable", false},
+		{"/password/2fa/recovery", false},
+		{"/password/passkey/begin", false},
+		{"/password/passkey/finish", false},
+		{"/password/passkey/remove", false},
+		{"/logout", false},
+		// Exactly what a prefix match would admit, and the reason the map's
+		// comment says exact: anything a later release mounts below an allowed
+		// path, and anything that merely starts with one.
+		{"/password/2fa/begin/extra", true},
+		{"/password/", true},
+		{"/passwordless", true},
+		{"/logout/everywhere", true},
+		// And an ordinary page, the case the gate exists for.
+		{"/dashboard", true},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			gate.ServeHTTP(rec, httptest.NewRequest("GET", tc.path, nil))
+
+			gated := rec.Header().Get("X-Easywall-Gate") != ""
+			if gated != tc.gated {
+				t.Fatalf("gated = %v, want %v (status %d, Location %q)",
+					gated, tc.gated, rec.Code, rec.Header().Get("Location"))
+			}
+			if tc.gated {
+				if rec.Code != http.StatusSeeOther || rec.Header().Get("Location") != "/password" {
+					t.Errorf("gated request answered %d to %q, want 303 to /password",
+						rec.Code, rec.Header().Get("Location"))
+				}
+				return
+			}
+			if rec.Code != http.StatusTeapot {
+				t.Errorf("answered %d; the request did not reach the handler behind the gate", rec.Code)
 			}
 		})
 	}


### PR DESCRIPTION
A 75-mutation audit of 2.18's guards ran after the release branch merged:
**56 red, 19 green, no shipping defect.** This closes the six worth closing and
records the rest.

Two were worse than coverage gaps, because a comment asserted what nothing held:

- **The gate's allowlist can become a prefix match undetected.** Its comment
  names that exact failure. No route registered today distinguishes exact from
  prefix, so nothing fails. Now held by a test that calls `RequireSecondFactor`
  directly rather than through the router.
- **`"/logout": true` is inert** — the route is public, so the middleware never
  sees it, and the test that appeared to cover it passed for that reason. The
  entry stays (moving `/logout` behind the gate would strip an operator of the
  only way out of it) but is now load-bearing.

**`publicOrigin()` could drop the port with the suite green.** The code is
correct; the gap is that every passkey test pins `BindAddr` to `:443`, where the
port branch is dead — while the default bind is `:12227`, and a wrong WebAuthn
origin fails every ceremony in the browser with nothing to see in Go.

Plus the 64-rune name bound (the old fixture was 65 runes *and* 130 bytes, so
byte-counting rejected it too), the acting session surviving a passkey removal,
and `wasFirstFactor`, whose own test was carried by the other half of its `&&`.

Thirteen remaining green mutations are in `docs-tech/carried-forward.md` with
their measurements — including that the ACME serving path has no unit coverage
at all, and that its integration test exits 1 with no message when it cannot
get `CAP_SYS_ADMIN`.

Every test here was verified by the mutation it exists to catch, one at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)