### PR TITLE
release: 2.18.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,51 @@
+easywall (2.18.0) unstable; urgency=medium
+
+  * Feat: a second factor is mandatory. An operator with none is sent to the
+    enrolment page after signing in, not refused at the login form, so an
+    upgrade locks nobody out. Demo mode is the one exemption. There is no
+    "remind me later", because the version of this with one is the version
+    nobody ever passes through.
+  * Feat: passkeys, as a second step and never a first. Several per account,
+    each named and dated, in passkeys.json under data_dir. Two conditions must
+    hold or the button is absent rather than broken: a registrable hostname in
+    [tls], and a certificate the browser trusts.
+  * Feat: ACME via Let's Encrypt, at the cost of no new dependency. HTTP-01
+    only. easywall never accepts a certificate authority's terms on the
+    operator's behalf, and never opens port 80 itself — it reads the rule set
+    and reports open, restricted, not covered, or unknown.
+  * Feat: a password needs twelve characters, a digit and a symbol. A symbol is
+    any rune that is neither letter nor digit, so a passphrase with a space
+    qualifies. Not configurable.
+  * Fix: an account whose only factor was a passkey was signed in by the
+    password alone. handleLoginPOST decided whether a second step existed by
+    reading the TOTP secret, which such an account does not have.
+  * Fix: the second-factor attempt budget was held in the client's own cookie,
+    so three attempts bound only a browser that sent back what the server gave
+    it. Measured at 200 guesses from one password round. It is now the
+    server's.
+  * Fix: signing out could be undone. Any save of a session re-signed its
+    cookie with a fresh timestamp, and three paths saved one they had not
+    authenticated, so a wrong password every nine minutes kept a revoked cookie
+    alive until the revocation record expired.
+  * Fix: an unreadable passkeys.json removed the mandate — a corrupt store read
+    as "no passkeys", and the password alone signed in. It now counts as a
+    factor, because the truth is unknown and the recovery codes still work.
+  * Fix: a passkey assertion could be replayed. The signature counter was no
+    backstop: go-webauthn exempts an authenticator reporting zero, which is
+    most platform passkeys.
+  * Fix: enrolling a passkey did not ask for the current password, the only
+    credential write on that page that did not.
+  * Fix: the documentation's last-resort recovery was wrong. Clearing
+    totp_secret and recovery_codes left an enrolled passkey standing as a
+    factor while destroying the eight codes. All five places now name
+    passkeys.json as the third thing to clear.
+  * Fix: an account whose only factor was a passkey could neither see how many
+    recovery codes remained nor mint new ones. They have their own card now —
+    they belong to the account, not to TOTP.
+  * Fix: the documentation landing page rendered as unstyled prose at full page
+    width for two releases. The guard read web/templates/ and app.js only.
+
+ -- JP <12394156+jp1337@users.noreply.github.com>  Fri, 11 Sep 2026 14:03:00 +0200
 easywall (2.17.0) unstable; urgency=medium
 
   * Fix: all three conntrack masks are native-endian. For five releases the

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,7 +16,7 @@ timezone: Europe/Berlin
 # Shown as the badge in the sidebar. Must match shared.CurrentVersion in
 # internal/shared/version.go — TestDocsVersionMatchesRelease enforces that.
 # It was hardcoded in the layout as "v2.4" and drifted a patch release behind.
-version: "2.17.0"
+version: "2.18.0"
 
 tagline: "Your firewall. Your rules. No surprises."
 logo: /assets/img/icon.svg

--- a/internal/shared/version.go
+++ b/internal/shared/version.go
@@ -27,7 +27,7 @@ import (
 // stylesheet URL never changed across an upgrade even though it is versioned
 // precisely so that it does. `easywall-core --version` prints this, so a build
 // can be checked rather than assumed.
-var CurrentVersion = "2.17.0"
+var CurrentVersion = "2.18.0"
 
 const (
 	// cacheMaxAge is how long a successful check is trusted.


### PR DESCRIPTION
The three pins that must move together, and only those.

| File | 2.17.0 → 2.18.0 | Pinned by |
|---|---|---|
| `internal/shared/version.go` | the version the binary reports | — (source of truth) |
| `docs/_config.yml` | the documentation sidebar badge | `TestDocsVersionMatchesRelease` |
| `debian/changelog` | the package version and `-ldflags` | `TestThePackageVersionIsTheReleaseVersion` |

`debian/changelog` verified with `dpkg-parsechangelog` rather than by reading —
it answers `2.18.0`. That file sat at 2.0.0 for five releases, which is why both
guards exist.

`CHANGELOG.md` and `docs/_docs/changelog.md` already carry the 2.18.0 section;
#173 wrote them.

Its own pull request because a direct push to `main` is refused, owner included:
a brand-new commit has no passing checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)