### PR TITLE
config, docs: the second factor stopped being optional in 2.18 and two pages still said it was

### DIFF
--- a/config/web.toml
+++ b/config/web.toml
@@ -94,8 +94,10 @@ username = ""
 password = ""  # argon2id hash, set by the first-run wizard
 
 # ─── Second factor ──────────────────────────────────────────────────────────
-# Written by the interface under Password → Second factor. Leave both empty to
-# sign in with a password alone.
+# Written by the interface under Password → Second factor. Leaving both empty
+# does not get you an interface without one: since 2.18 a second factor is a
+# precondition for using easywall, so signing in with nothing enrolled lands on
+# Password → Second factor and goes nowhere else until one is.
 #
 # totp_secret is the base32 shared secret your authenticator app holds.
 # recovery_codes holds the argon2id hashes of the eight one-time codes — never
@@ -104,7 +106,9 @@ password = ""  # argon2id hash, set by the first-run wizard
 # Locked out with the phone gone and the codes gone? Three things to clear, not
 # two, and no longer all of them in this file: empty both lines below, delete
 # passkeys.json in data_dir (set at the top of this file — /var/lib/easywall by
-# default), then restart easywall-web. The password alone signs you in again.
+# default), then restart easywall-web. The password alone signs you in again —
+# onto Password → Second factor, where you enrol a new one before the rest of
+# the interface opens. That is the way back in, not a way to stay without one.
 # A passkey left behind is a second factor of its own: it still sends you to
 # /login/verify, where the browser may refuse to offer it at all.
 totp_secret    = ""

--- a/docs/_docs/features/two-factor.md
+++ b/docs/_docs/features/two-factor.md
@@ -129,8 +129,11 @@ still asks for it:
 | `recovery_codes = []` | `web.toml` on the host |
 | delete `passkeys.json` | your `data_dir` — `/var/lib/easywall` unless you changed it |
 
-Restart `easywall-web`. The password alone signs you in again. There is no reset
-link: this interface sends no mail and reaches no outside service.
+Restart `easywall-web`. The password alone signs you in again — onto
+**Password → Second factor**, where you enrol a new one before the rest of the
+interface opens. Clearing all three is the way back in, not a way to run
+without a factor. There is no reset link: this interface sends no mail and
+reaches no outside service.
 
 Every step above — enrolling, signing in with a code, using a recovery code,
 issuing new ones, a wrong code, or a factor switched off — is recorded. See


### PR DESCRIPTION
`config/web.toml` told the operator *"Leave both empty to sign in with a password alone"*, and `features/two-factor.md` ended its lockout recovery with *"The password alone signs you in again"*. Both describe easywall before 2.18.

`RequireSecondFactor` (`internal/web/middleware.go:115`) is mounted on the authenticated group and lets nothing through except the enrolment routes and `/logout`. `factorCount()` is zero with `totp_secret` empty and no passkeys, so the sign-in succeeds — `handleLoginPOST` still grants the session, which is what keeps an upgrade from stranding anybody — and every page after it redirects to `/password`.

That makes the old sentences wrong in the direction that matters. An operator clearing three files to get back in after losing a phone was told they would be back to normal; what actually happens is that they land on the enrolment page and stay there until they enrol.

Found while checking whether a configuration-managed host can bootstrap easywall without a browser. It can — `totp_secret` is a config key — but the file describing that key was describing the release before last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)