### PR TITLE
build(deps): pin lodash-es above its code-injection advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,18 @@ nothing about it. A port rule can now name that traffic.
   Scope column's German option truncated in a rendered select twice while every
   gate stayed green.
 
+### Security
+
+- **`lodash-es` is pinned above its code-injection advisory.** mermaid 12 brought
+  `chevrotain` 11.1.2, which resolves `lodash-es` 4.17.23 — GHSA-r5fr-rjxr-66jc,
+  code injection through `_.template`, and GHSA-f23m-r3pf-42rh, prototype
+  pollution in `_.unset` and `_.omit`. An `overrides` entry takes 4.18.1, which
+  `dagre-d3-es` in the same tree already resolved to, so the version is one the
+  build was carrying anyway. **Build-time only**: neither the container nor the
+  `.deb` contains `node_modules`, and `htmx.min.js` is vendored — the one place
+  this code ran is rendering the documentation diagrams. Those render
+  byte-identically afterwards, which `check:diagrams` asserts by digest.
+
 ## [2.18.0] — 2026-09-11
 
 **A password alone is not enough.**

--- a/docs/_docs/changelog.md
+++ b/docs/_docs/changelog.md
@@ -131,6 +131,18 @@ nothing about it. A port rule can now name that traffic.
   Scope column's German option truncated in a rendered select twice while every
   gate stayed green.
 
+### Security
+
+- **`lodash-es` is pinned above its code-injection advisory.** mermaid 12 brought
+  `chevrotain` 11.1.2, which resolves `lodash-es` 4.17.23 — GHSA-r5fr-rjxr-66jc,
+  code injection through `_.template`, and GHSA-f23m-r3pf-42rh, prototype
+  pollution in `_.unset` and `_.omit`. An `overrides` entry takes 4.18.1, which
+  `dagre-d3-es` in the same tree already resolved to, so the version is one the
+  build was carrying anyway. **Build-time only**: neither the container nor the
+  `.deb` contains `node_modules`, and `htmx.min.js` is vendored — the one place
+  this code ran is rendering the documentation diagrams. Those render
+  byte-identically afterwards, which `check:diagrams` asserts by digest.
+
 [See everything changed since the last release](https://github.com/jp1337/easywall/compare/v2.18.0...HEAD)
 
 </details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,13 +48,6 @@
         "lodash-es": "4.17.23"
       }
     },
-    "node_modules/@chevrotain/cst-dts-gen/node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@chevrotain/gast": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.2.tgz",
@@ -65,13 +58,6 @@
         "@chevrotain/types": "11.1.2",
         "lodash-es": "4.17.23"
       }
-    },
-    "node_modules/@chevrotain/gast/node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@chevrotain/regexp-to-ast": {
       "version": "11.1.2",
@@ -1207,13 +1193,6 @@
         "@chevrotain/utils": "11.1.2",
         "lodash-es": "4.17.23"
       }
-    },
-    "node_modules/chevrotain/node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   },
   "dependencies": {
     "htmx.org": "^2.0.10"
+  },
+  "overrides": {
+    "lodash-es": "^4.18.0"
   }
 }


### PR DESCRIPTION
Two Dependabot alerts, both against `lodash-es` 4.17.23:

| | |
|---|---|
| `GHSA-r5fr-rjxr-66jc` | **high** — code injection through `_.template` |
| `GHSA-f23m-r3pf-42rh` | medium — prototype pollution in `_.unset` and `_.omit` |

They arrived with **mermaid 12**, merged earlier today. mermaid pins `chevrotain` 11.1.2, which resolves `lodash-es` 4.17.23 in three places — while `dagre-d3-es` in the same tree already resolved **4.18.1**. The patched version was being carried alongside the vulnerable one. An `overrides` entry takes 4.18.1 everywhere.

**Not a chevrotain bump.** mermaid 12.0.0 pins 11.1.2 and the current release is 13.2.0. Forcing a major on the parser a diagram renderer is built around is a larger risk than the thing it would fix.

## Scope — measured, not assumed

Neither the `Dockerfile` nor `debian/rules` mentions npm or `node_modules`, and `htmx.min.js` is vendored into `web/static/`. **No npm package reaches a shipped artefact.** The one place this code ran is rendering the documentation diagrams.

Those render **byte-identically** afterwards — `check:diagrams` asserts it by `data-source-digest`, not by diff, so mermaid's bezier jitter cannot hide a real change.

## Verified

- `npm audit` — 0 vulnerabilities, with and without dev dependencies
- `npm run check:diagrams` — 9 diagrams, all current
- `build:css` and `build:docs-css` rebuild byte-identical
- `check:docs`, `check:changelog`, `check:prose` — pass

## Why now

2.19 is merged to `main` but **not tagged**. This lands before the tag rather than as a patch after it: a firewall that ships a release with a reported vulnerability, and patches it later, asks every operator who installs in that window to install the hole knowingly left in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)