### PR TITLE
release: 2.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.19.0] — 2026-09-12
 
 **What it passes on, it also filters.**
 
@@ -2005,8 +2005,8 @@ After explicit configuration the following ICMPv6 types are allowed additionally
 - easywall Firewall Core Part running as root user finished
 - The New easywall will be one part running as root and one part running as easywall user which has access to config files.
 
-[unreleased]: https://github.com/jp1337/easywall/compare/v2.18.0...HEAD
-[Unreleased]: https://github.com/jp1337/easywall/compare/v2.18.0...HEAD
+[Unreleased]: https://github.com/jp1337/easywall/compare/v2.19.0...HEAD
+[2.19.0]: https://github.com/jp1337/easywall/compare/v2.18.0...v2.19.0
 [2.18.0]: https://github.com/jp1337/easywall/compare/v2.17.0...v2.18.0
 [2.17.0]: https://github.com/jp1337/easywall/compare/v2.16.0...v2.17.0
 [2.16.0]: https://github.com/jp1337/easywall/compare/v2.15.1...v2.16.0

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,30 @@
+easywall (2.19.0) unstable; urgency=medium
+
+  * Feat: a port rule can name traffic this host forwards to a container, not
+    only traffic addressed to it. A published container port is routed, not
+    received, so it crosses the forward chain and never input — on a measured
+    host that meant four of fourteen open ports reached easywall's rules. A
+    rule now carries a scope: host, forwarded, or both.
+  * Feat: [docker] published_ports, "open" by default and unchanged from 2.18.
+    Under "filtered" the forward chain gains the forwarded accepts and the deny
+    that gives them meaning, ordered before the CIDR exceptions — because a
+    rule rendered after them can never refuse anything.
+  * Feat: a forwarded rule's kernel counter is read. RuleCounters walked the
+    input chain alone, so such a rule reported "never used" for ever while
+    carrying a host's entire mail service.
+  * Fix: the SSH brute-force limiter metered ports from every rule regardless
+    of scope, and its empty-list fallback then suppressed the default port-22
+    protection. A forwarded SSH rule silently turned the limiter off.
+  * Fix: a forwarded accept naming no source carried no address-family test in
+    an inet table, so it matched forwarded IPv6 that 2.18's policy drop refused.
+  * Security: lodash-es is pinned above GHSA-r5fr-rjxr-66jc and
+    GHSA-f23m-r3pf-42rh, both of which arrived with mermaid 12. Build-time only;
+    no npm package reaches a shipped artefact.
+  * check:ui can now see a select truncating and reads German, which closed the
+    carried-forward entry about its English-only sweep.
+
+ -- JP <12394156+jp1337@users.noreply.github.com>  Sat, 12 Sep 2026 18:30:00 +0200
+
 easywall (2.18.0) unstable; urgency=medium
 
   * Feat: a second factor is mandatory. An operator with none is sent to the

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,7 +16,7 @@ timezone: Europe/Berlin
 # Shown as the badge in the sidebar. Must match shared.CurrentVersion in
 # internal/shared/version.go — TestDocsVersionMatchesRelease enforces that.
 # It was hardcoded in the layout as "v2.4" and drifted a patch release behind.
-version: "2.18.0"
+version: "2.19.0"
 
 tagline: "Your firewall. Your rules. No surprises."
 logo: /assets/img/icon.svg

--- a/docs/_docs/changelog.md
+++ b/docs/_docs/changelog.md
@@ -16,7 +16,7 @@ until you open them. This page is generated from
 which is the file GitHub and the release tooling read.
 
 <nav class="changelog-versions" aria-label="Versions">
-  <a href="#Unreleased">Unreleased</a>
+  <a href="#2.19.0">2.19.0</a>
   <a href="#2.18.0">2.18.0</a>
   <a href="#2.17.0">2.17.0</a>
   <a href="#2.16.0">2.16.0</a>
@@ -67,8 +67,8 @@ which is the file GitHub and the release tooling read.
   addEventListener('hashchange', openTarget);
 </script>
 
-<details open id="Unreleased" markdown="1">
-<summary><strong>Unreleased</strong> — What it passes on, it also filters</summary>
+<details open id="2.19.0" markdown="1">
+<summary><strong>2.19.0</strong> · 2026-09-12 — What it passes on, it also filters</summary>
 
 A published container port is routed to the container, not addressed to the
 host, so it crosses the `forward` chain and never `input`. On a measured host
@@ -143,7 +143,7 @@ nothing about it. A port rule can now name that traffic.
   this code ran is rendering the documentation diagrams. Those render
   byte-identically afterwards, which `check:diagrams` asserts by digest.
 
-[See everything changed since the last release](https://github.com/jp1337/easywall/compare/v2.18.0...HEAD)
+[See the code changes between 2.18.0 and 2.19.0](https://github.com/jp1337/easywall/compare/v2.18.0...v2.19.0)
 
 </details>
 

--- a/internal/shared/version.go
+++ b/internal/shared/version.go
@@ -27,7 +27,7 @@ import (
 // stylesheet URL never changed across an upgrade even though it is versioned
 // precisely so that it does. `easywall-core --version` prints this, so a build
 // can be checked rather than assumed.
-var CurrentVersion = "2.18.0"
+var CurrentVersion = "2.19.0"
 
 const (
 	// cacheMaxAge is how long a successful check is trusted.


### PR DESCRIPTION
**What it passes on, it also filters.**

A published container port is routed to the container, not addressed to the host, so it crosses the `forward` chain and never `input`. On a measured host that meant **four of fourteen** open ports reached easywall's rules and ten were filtered by somebody else — with the dashboard reporting *Active* and saying nothing about it.

## The four places that must agree

| | |
|---|---|
| `CHANGELOG.md` | `[Unreleased]` → `[2.19.0] — 2026-09-12` |
| `internal/shared/version.go` | `CurrentVersion = "2.19.0"` |
| `docs/_config.yml` | `version: "2.19.0"` |
| `debian/changelog` | new `2.19.0` entry — `debian/rules` takes the package version from it |

## One thing the version guard caught

`CHANGELOG.md` carried **two** `[Unreleased]` link definitions on `main` — a lowercase and a capitalised one, both pointing at `v2.18.0`. Markdown link references are case-insensitive, so the duplicate was invisible while they agreed, and `TestUnreleasedComparesAgainstTheNewestRelease` passed by coincidence rather than because the file was right.

Updating one of them made them disagree and the guard failed — the first time anything had looked at that line. The duplicate is removed.

## Verified

`go test ./internal/...` · `golangci-lint` 0 issues · `check:changelog` (36 versions, 36 sections, 38 link definitions — agreed) · `check:prose` · `check:docs` · `check:diagrams`

Dependabot: **0 open alerts** — the two `lodash-es` advisories that arrived with mermaid 12 were closed in #183, before this tag rather than after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)